### PR TITLE
Adds toggle for audio descriptions

### DIFF
--- a/src/pages/YDXHome.js
+++ b/src/pages/YDXHome.js
@@ -76,6 +76,8 @@ const YDXHome = (props) => {
   const [isCurrentExtACPaused, setCurrentExtACPaused] = useState(false); // Manages the play/pause state of an extended audio clip
   const [isGloballyPaused, setGloballyPaused] = useState(true); // Manages the global play/pause state
 
+  const [hasAudioDescriptionsEnabled, setAudioDescriptionsEnabled] = useState(false); // Manages the state for audio descriptions (enabled/disabled)
+
   useEffect(() => {
     setDivWidths({
       divRef1:
@@ -246,6 +248,9 @@ const YDXHome = (props) => {
     setDraggableTime({ x: unitLength * time, y: 0 });
     // check if the audio is not played recently. do not play it again.
     if (parseFloat(recentAudioPlayedTime) !== parseFloat(time)) {
+      if (!hasAudioDescriptionsEnabled) { // Skip playing if audio descriptions are playing
+        return;
+      }
       // To Play audio files based on current time
       playAudioAtCurrentTime(time, playedAudioClip, playedClipPath);
     }
@@ -321,6 +326,7 @@ const YDXHome = (props) => {
     switch (event.data) {
       case 0: // end of the video
         clearInterval(timer);
+        setAudioDescriptionsEnabled(true);
         event.target.seekTo(0);
         break;
       case 1: // Playing
@@ -480,6 +486,12 @@ const YDXHome = (props) => {
     }
   };
 
+  const handleAudioDescriptions = (newStatus) => {
+    if (currentState !== 1){
+      setAudioDescriptionsEnabled(newStatus)
+    }
+  }
+
   return (
     <React.Fragment>
       {/* Spinner div - displayed based on showSpinner */}
@@ -509,6 +521,35 @@ const YDXHome = (props) => {
             notesData={notesData}
           />
         </div>
+        <div className="px-5 py-2 d-flex align-items-center">
+          <h6 className="dialog-timeline-text text-center fw-bolder text-white mx-4">
+            Audio Descriptions:
+          </h6>
+          <div className="btn-group btn-toggle">
+            <button
+              className={[
+                "btn btn-sm",
+                hasAudioDescriptionsEnabled
+                  ? "btn-primary active"
+                  : "btn-light",
+              ].join(" ")}
+              onClick={() => handleAudioDescriptions(true)}
+            >
+              ON
+            </button>
+            <button
+              className={[
+                "btn btn-sm",
+                hasAudioDescriptionsEnabled
+                  ? "btn-light"
+                  : "btn-primary active",
+              ].join(" ")}
+              onClick={() => handleAudioDescriptions(false)}
+            >
+              OFF
+            </button>
+          </div>
+        </div>
         <hr className="m-2" />
         {/* Dialog Timeline */}
         <div className="row div-below-hr">
@@ -532,7 +573,7 @@ const YDXHome = (props) => {
                       className="dialog-timestamps-div"
                       style={{
                         width: dialog.width,
-                        height: '20px',
+                        height: "20px",
                       }}
                     ></div>
                   </Draggable>


### PR DESCRIPTION
This PR includes the following changes:
- Adds a toggle button for enabling/disabling audio descriptions

#### How it works
- The local state variable manages to audio descriptions state. The audio descriptions are disabled by default.
- The button group can be used to toggle audio descriptions on and off. However,  the buttons are disabled when the video is playing because the audio descriptions logic runs asynchronously and cannot be changed when the video is playing.
- If the video is paused, the buttons can be used to turn the audio descriptions on or off.
- When the video ends, the audio descriptions are toggled on automatically.