### PR TITLE
fix inline audio state cleanup after seek

### DIFF
--- a/src/pages/PublishedAudioDescriptions/PublishedAudioDescriptions.tsx
+++ b/src/pages/PublishedAudioDescriptions/PublishedAudioDescriptions.tsx
@@ -952,7 +952,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
       currentInlineACRef.current.pause()
       currentInlineACRef.current.seek(0)
       currentInlineACRef.current.unload()
-      setCurrExtendedAC(undefined)
+      setCurrInlineAC(undefined)
       // currentEvent?.playVideo()
     }
   }

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -1018,7 +1018,7 @@ const YDXHome = (): React.ReactElement => {
       currentInlineACRef.current.pause()
       currentInlineACRef.current.seek(0)
       currentInlineACRef.current.unload()
-      setCurrExtendedAC(undefined)
+      setCurrInlineAC(undefined)
       // currentEvent?.playVideo()
     }
   }


### PR DESCRIPTION
## Description

Fixes a small seek cleanup bug in the editor and published playback pages.

## Motivation and Context

When inline audio was unloaded after seeking, the code cleared the extended-audio state instead of the inline-audio state.

## How has this been tested?

Locally tested.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.