### PR TITLE
Rebuild editor playback state after save and restore row toggles on refresh

### DIFF
--- a/src/features/Describe/NewAudioClip/NewAudioClip.tsx
+++ b/src/features/Describe/NewAudioClip/NewAudioClip.tsx
@@ -183,6 +183,8 @@ const NewAudioClipComponent = ({
       )
       toast.success(`New Clip Added Successfully!!\n${response.data}`)
       setShowNewACComponent(false)
+      // Flag the next refresh as save-triggered so the editor rebuilds from
+      // the current playback position instead of resetting to the start.
       window.dispatchEvent(new Event('ydx:new-clip-saved'))
       setNeedRefresh(true)
       setRecordingDuration(0)

--- a/src/features/Describe/NewAudioClip/NewAudioClip.tsx
+++ b/src/features/Describe/NewAudioClip/NewAudioClip.tsx
@@ -183,6 +183,7 @@ const NewAudioClipComponent = ({
       )
       toast.success(`New Clip Added Successfully!!\n${response.data}`)
       setShowNewACComponent(false)
+      window.dispatchEvent(new Event('ydx:new-clip-saved'))
       setNeedRefresh(true)
       setRecordingDuration(0)
     } catch (error) {

--- a/src/pages/YDXHome.test.tsx
+++ b/src/pages/YDXHome.test.tsx
@@ -1,0 +1,309 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import axios from 'axios'
+import YDXHome from './YDXHome'
+
+jest.mock('axios')
+
+const mockNavigate = jest.fn()
+const mockedAxios = axios as jest.Mocked<typeof axios>
+const audioDescriptionResponses: any[] = []
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({
+    audioDescriptionId: 'ad-1',
+    youtubeVideoId: 'youtube-1',
+  }),
+}))
+
+jest.mock(
+  '@/App',
+  () => ({
+    userDataStore: {
+      getState: () => ({
+        userId: 'user-1',
+      }),
+    },
+  }),
+  { virtual: true },
+)
+
+jest.mock('use-elapsed-time', () => ({
+  useElapsedTime: () => ({
+    elapsedTime: 0,
+  }),
+}))
+
+jest.mock('debounce', () => ({
+  debounce: (fn: (...args: any[]) => unknown) => fn,
+}))
+
+jest.mock('react-youtube', () => ({
+  __esModule: true,
+  default: () => <div data-testid="youtube-player" />,
+}))
+
+jest.mock('react-draggable', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+jest.mock('../features/Describe/Buttons/Buttons', () => ({
+  Buttons: () => <div data-testid="buttons" />,
+}))
+
+jest.mock('../features/Describe/Notes/Notes', () => ({
+  __esModule: true,
+  default: () => <div data-testid="notes" />,
+}))
+
+jest.mock('../features/Describe/InsertPublish/InsertPublish', () => ({
+  __esModule: true,
+  default: () => <div data-testid="insert-publish" />,
+}))
+
+jest.mock('../shared/components/Spinner/Spinner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="spinner" />,
+}))
+
+jest.mock('react-bootstrap/Button', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}))
+
+jest.mock('howler', () => {
+  class MockHowl {
+    load = jest.fn()
+    unload = jest.fn()
+    pause = jest.fn()
+    seek = jest.fn()
+    play = jest.fn()
+    once = jest.fn()
+    on = jest.fn()
+    volume = jest.fn()
+    state = jest.fn(() => 'loaded')
+    playing = jest.fn(() => false)
+  }
+
+  return {
+    Howl: MockHowl,
+  }
+})
+
+jest.mock('../features/Describe/AudioClip/AudioClip', () => ({
+  __esModule: true,
+  default: ({
+    clip,
+    editComponentToggleList,
+    setNeedRefresh,
+    setUndoDeletedClip,
+  }: any) => {
+    const hasToggle = editComponentToggleList.some(
+      (item: { clipId: string }) => item.clipId === clip.clip_id,
+    )
+
+    return (
+      <div
+        data-testid={`clip-${clip.clip_id}`}
+        data-has-toggle={String(hasToggle)}
+      >
+        <span>{clip.clip_id}</span>
+        <button
+          type="button"
+          data-testid={`trigger-refresh-${clip.clip_id}`}
+          onClick={() => setNeedRefresh(true)}
+        >
+          Trigger Refresh
+        </button>
+        <button
+          type="button"
+          data-testid={`trigger-delete-refresh-${clip.clip_id}`}
+          onClick={() => {
+            setUndoDeletedClip(true)
+            setNeedRefresh(true)
+          }}
+        >
+          Trigger Delete Refresh
+        </button>
+      </div>
+    )
+  },
+}))
+
+const makeClip = (overrides: Partial<Record<string, any>> = {}) => ({
+  AudioDescriptionAdId: 'ad-1',
+  clip_audio_path: '/audio/test-clip.mp3',
+  clip_duration: 2,
+  clip_end_time: 12,
+  clip_id: 'clip-1',
+  clip_sequence_number: 1,
+  clip_start_time: 10,
+  clip_title: 'Clip title',
+  createdAt: '2026-03-01T00:00:00.000Z',
+  description_text: 'Description',
+  description_type: 'Visual',
+  is_recorded: false,
+  playback_type: 'inline',
+  updatedAt: '2026-03-01T00:00:00.000Z',
+  ...overrides,
+})
+
+const makeAudioDescriptionResponse = (clips: any[]) => ({
+  Audio_Clips: clips,
+  Notes: ['Notes'],
+  is_collaborative_version: false,
+  is_published: false,
+})
+
+const queueAudioDescriptionResponses = (...responses: any[]) => {
+  audioDescriptionResponses.length = 0
+  audioDescriptionResponses.push(...responses)
+}
+
+describe('YDXHome refresh alignment', () => {
+  beforeEach(() => {
+    audioDescriptionResponses.length = 0
+    mockedAxios.get.mockReset()
+    mockedAxios.post.mockReset()
+    mockNavigate.mockReset()
+    localStorage.clear()
+    sessionStorage.clear()
+
+    mockedAxios.get.mockImplementation((url) => {
+      if (url.includes('/api/videos/get-by-youtubeVideo/')) {
+        return Promise.resolve({
+          data: {
+            video_id: 'video-1',
+            video_length: 120,
+          },
+        })
+      }
+
+      if (url.includes('/api/dialog-timestamps/get-video-dialog/')) {
+        return Promise.resolve({
+          data: [],
+        })
+      }
+
+      if (url.includes('/api/audio-descriptions/get-user-ad/')) {
+        const nextResponse =
+          audioDescriptionResponses.length > 1
+            ? audioDescriptionResponses.shift()
+            : audioDescriptionResponses[0]
+
+        if (!nextResponse) {
+          throw new Error(`Missing audio description response for ${url}`)
+        }
+
+        return Promise.resolve({
+          data: nextResponse,
+        })
+      }
+
+      throw new Error(`Unexpected axios.get URL: ${url}`)
+    })
+
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        clip: {
+          audio_description: 'ad-1',
+          youtubeId: 'youtube-1',
+        },
+      },
+    })
+  })
+
+  it('rebuilds edit toggles on a non-save refresh from a clip row', async () => {
+    queueAudioDescriptionResponses(
+      makeAudioDescriptionResponse([makeClip()]),
+      makeAudioDescriptionResponse([makeClip()]),
+      makeAudioDescriptionResponse([
+        makeClip(),
+        makeClip({
+          clip_id: 'clip-2',
+          clip_start_time: 20,
+          clip_end_time: 22,
+        }),
+      ]),
+    )
+
+    render(<YDXHome />)
+
+    expect(await screen.findByTestId('clip-clip-1')).toHaveAttribute(
+      'data-has-toggle',
+      'true',
+    )
+
+    fireEvent.click(screen.getByTestId('trigger-refresh-clip-1'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('clip-clip-1')).toHaveAttribute(
+        'data-has-toggle',
+        'true',
+      )
+      expect(screen.getByTestId('clip-clip-2')).toHaveAttribute(
+        'data-has-toggle',
+        'true',
+      )
+    })
+  })
+
+  it('rebuilds edit toggles after undo restores clips through the non-save refresh path', async () => {
+    queueAudioDescriptionResponses(
+      makeAudioDescriptionResponse([makeClip()]),
+      makeAudioDescriptionResponse([makeClip()]),
+      makeAudioDescriptionResponse([]),
+      makeAudioDescriptionResponse([
+        makeClip(),
+        makeClip({
+          clip_id: 'clip-restored',
+          clip_start_time: 30,
+          clip_end_time: 33,
+        }),
+      ]),
+    )
+
+    render(<YDXHome />)
+
+    expect(await screen.findByTestId('clip-clip-1')).toHaveAttribute(
+      'data-has-toggle',
+      'true',
+    )
+
+    fireEvent.click(screen.getByTestId('trigger-delete-refresh-clip-1'))
+
+    const undoButton = await screen.findByRole('button', {
+      name: /undo last deleted/i,
+    })
+
+    fireEvent.click(undoButton)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/editor/youtube-1/ad-1')
+      expect(screen.getByTestId('clip-clip-restored')).toHaveAttribute(
+        'data-has-toggle',
+        'true',
+      )
+    })
+  })
+})

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -147,6 +147,7 @@ const YDXHome = (): React.ReactElement => {
   const currentStateRef = useRef(currentState)
   const currentInlineACRef = useRef(currInlineAC)
   const currentExtendedACRef = useRef(currExtendedAC)
+  const savedClipRefreshRequestedRef = useRef(false)
 
   useEffect(() => {
     currentInlineACRef.current = currInlineAC
@@ -262,8 +263,22 @@ const YDXHome = (): React.ReactElement => {
   }, [currentState])
 
   useEffect(() => {
+    const handleSavedClipRefresh = () => {
+      savedClipRefreshRequestedRef.current = true
+    }
+
+    window.addEventListener('ydx:new-clip-saved', handleSavedClipRefresh)
+
+    return () => {
+      window.removeEventListener('ydx:new-clip-saved', handleSavedClipRefresh)
+    }
+  }, [])
+
+  useEffect(() => {
     if (needRefresh) {
-      fetchAudioDescriptionData(true)
+      const isNewClipAdded = savedClipRefreshRequestedRef.current
+      savedClipRefreshRequestedRef.current = false
+      fetchAudioDescriptionData(isNewClipAdded)
       setNeedRefresh(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -366,6 +381,90 @@ const YDXHome = (): React.ReactElement => {
       })
   }
 
+  const unloadHowls = useCallback((howls: Array<Howl | undefined>) => {
+    const unloadedHowls = new Set<Howl>()
+
+    howls.forEach((howl) => {
+      if (!howl || unloadedHowls.has(howl)) {
+        return
+      }
+
+      unloadedHowls.add(howl)
+      howl.pause()
+      howl.seek(0)
+      howl.unload()
+    })
+  }, [])
+
+  const getClipStackStartIndex = useCallback(
+    (clips: Clip[], targetTime: number) => {
+      const startIndex = clips.findIndex(
+        (clip) =>
+          clip.clip_start_time >= targetTime ||
+          (clip.clip_start_time < targetTime &&
+            clip.clip_end_time > targetTime),
+      )
+
+      return startIndex === -1 ? clips.length : startIndex
+    },
+    [],
+  )
+
+  const primeClipAudio = useCallback((clip: Clip) => {
+    if (clip.clip_audio) {
+      clip.clip_audio.unload()
+      clip.clip_audio = undefined
+    }
+
+    clip.clip_audio = new Howl({
+      src: clip.clip_audio_path,
+      html5: true,
+      preload: true,
+      autoplay: false,
+    })
+    clip.clip_audio.load()
+
+    return clip
+  }, [])
+
+  const buildClipStackForTime = useCallback(
+    (clips: Clip[], targetTime: number, stackSize: number) => {
+      const startIndex = getClipStackStartIndex(clips, targetTime)
+      const clipStackData: Clip[] = []
+
+      for (
+        let i = startIndex;
+        i < Math.min(startIndex + stackSize, clips.length);
+        i++
+      ) {
+        const clip = clips[i]
+
+        if (clip) {
+          clipStackData.push(primeClipAudio(clip))
+        }
+      }
+
+      return { startIndex, clipStackData }
+    },
+    [getClipStackStartIndex, primeClipAudio],
+  )
+
+  const resetPlaybackStateForSavedClipRefresh = useCallback(() => {
+    unloadHowls([
+      ...clipStackRef.current.map((clip) => clip.clip_audio),
+      currentExtendedACRef.current,
+      currentInlineACRef.current,
+    ])
+
+    setCurrExtendedAC(undefined)
+    setCurrInlineAC(undefined)
+    setCurrentExtACPaused(false)
+    setRecentAudioPlayedTime(0.0)
+    setPlayedAudioClip('')
+    setPlayedClipPath('')
+    setPlayedClipsSet(new Set())
+  }, [unloadHowls])
+
   // use axios to get audio descriptions for the videoId (set in fetchUserVideoData()) & userId passed to the url Params
   const fetchAudioDescriptionData = (
     isNewClipAdded = false,
@@ -461,6 +560,24 @@ const YDXHome = (): React.ReactElement => {
           // console.log(audioClipsData)
           // // console.log("Audio Clips", audioClips);
           setNotesData(notesData)
+
+          if (isNewClipAdded) {
+            const nextClipStackSize =
+              audioClipsData.length > 100 ? 10 : clipStackSize
+
+            resetPlaybackStateForSavedClipRefresh()
+
+            const { startIndex, clipStackData } = buildClipStackForTime(
+              audioClipsData,
+              currentTimeRef.current,
+              nextClipStackSize,
+            )
+
+            setCurrentClipIndex(startIndex)
+            setClipStack(clipStackData)
+            return
+          }
+
           const maxStackSize =
             audioClipsData.length > 100
               ? 10

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -561,6 +561,8 @@ const YDXHome = (): React.ReactElement => {
           // // console.log("Audio Clips", audioClips);
           setNotesData(notesData)
 
+          // Save-triggered refreshes rebuild the playback window around the
+          // current player time so a newly added clip can play without a seek.
           if (isNewClipAdded) {
             const nextClipStackSize =
               audioClipsData.length > 100 ? 10 : clipStackSize

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -278,7 +278,7 @@ const YDXHome = (): React.ReactElement => {
     if (needRefresh) {
       const isNewClipAdded = savedClipRefreshRequestedRef.current
       savedClipRefreshRequestedRef.current = false
-      fetchAudioDescriptionData(isNewClipAdded)
+      fetchAudioDescriptionData(isNewClipAdded, undefined, true)
       setNeedRefresh(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -469,6 +469,7 @@ const YDXHome = (): React.ReactElement => {
   const fetchAudioDescriptionData = (
     isNewClipAdded = false,
     passedVideoId?: string,
+    shouldRefreshEditToggleList = false,
   ) => {
     //  this API fetches the audioDescription and all related AudioClips based on the UserID & VideoID
     const effectiveVideoId = passedVideoId || videoId
@@ -553,7 +554,10 @@ const YDXHome = (): React.ReactElement => {
             }
           })
 
-          if (editComponentToggleList.length === 0 || isNewClipAdded) {
+          if (
+            editComponentToggleList.length === 0 ||
+            shouldRefreshEditToggleList
+          ) {
             setEditComponentToggleList(tempArray)
           }
           setAudioClips([...audioClipsData])


### PR DESCRIPTION
## TL;DR

This is PR1 in a stacked editor playback/save sequence.
It fixes refresh behavior only: after a successful new clip save, the editor rebuilds playback state from the current player time, and non-save refreshes rebuild row toggle state so delete/undo/restore rows still expand/collapse correctly.

## Description

This PR is the **first PR in a stacked sequence** for the editor playback/save issues.

After a successful new clip save, the editor rebuilds its in-memory playback window from the **current player time** instead of keeping a stale clip stack or reseeding from the start of the audio-description clip list.

It also fixes a non-save refresh regression introduced by that split: delete/undo/restore refreshes now rebuild `editComponentToggleList`, so refreshed and restored clip rows still expand/collapse correctly.

The scope of this PR is intentionally narrow. It only covers:
- save-triggered playback-window rebuild after successful new clip save
- non-save refresh toggle-state rebuild needed to preserve row expand/collapse behavior

### Key changes
- dispatch a `ydx:new-clip-saved` event after a successful new clip save
- detect save-triggered refreshes separately from generic refreshes
- reset stale playback state during a save-triggered refresh
- rebuild `clipStack` and `currentClipIndex` from the current player time using refreshed clip data
- prime the rebuilt stack with fresh `Howl` instances
- rebuild `editComponentToggleList` on explicit non-save refreshes so refreshed/restored rows keep working expand/collapse state

## Motivation and Context

This PR fixes two refresh-path issues in the editor.

### Before this change
- after saving a new clip, the refreshed clip list could load, but the in-memory playback stack could still reflect the old playback window
- replay/resume without a manual seek could miss the newly saved clip
- saving near the end of the timeline could leave playback in a bad state or effectively push behavior back toward the start
- after separating save-triggered refresh from generic refreshes, non-save refreshes such as delete/undo/restore could refresh clip rows without rebuilding their per-row expand/collapse state

### After this change
- save-triggered refreshes rebuild the editor playback stack from the current player time
- newly saved clips are included in the refreshed playback window
- if the saved clip is the final clip, the rebuilt stack can correctly become empty instead of reloading from the beginning
- non-save refreshes rebuild `editComponentToggleList`, so restored and refreshed clip rows still expand/collapse correctly

## Scope / Follow-up Work

This PR is intentionally limited to refresh behavior only.

Out of scope for this PR:
- insert-time correctness for new clip creation
- queue correctness / duplicate playback stability
- post-save alignment to the final saved clip start time
- timeline render/scale issues
- broader timing/display polish

Known limitation:
- a just-saved extended clip can still be missed after a slow save/refetch; post-save alignment is handled in a later PR

Those are being handled in follow-up stacked PRs.

## How has this been tested?

### Automated
```bash
npx eslint src/pages/YDXHome.tsx src/features/Describe/NewAudioClip/NewAudioClip.tsx src/pages/YDXHome.test.tsx
CI=true npm test -- --watchAll=false --runTestsByPath src/pages/YDXHome.test.tsx
```

Result:
- eslint exits successfully with existing warnings
- targeted regression tests pass

Added targeted regression tests for:
- non-save refresh rebuilding clip edit-toggle alignment
- undo/restore rebuilding toggle state for restored rows

### Manual editor scenarios
- save a new inline clip, then replay/resume without manual seek
- save a new extended clip and verify the refreshed playback window includes it
- save near the end of the timeline and verify playback does not rebuild from the beginning
- verify delete -> refresh keeps clip row expand/collapse working
- verify undo/restore brings back a row whose detailed editor can still be expanded/collapsed normally
- verify restored rows still mount the detailed editor correctly

## Screenshots (if appropriate)

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not w

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
