### PR TITLE
Fix insert Start Time snapshot behavior

### DIFF
--- a/src/features/Describe/InsertPublish/InsertPublish.test.tsx
+++ b/src/features/Describe/InsertPublish/InsertPublish.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import axios from 'axios'
+import InsertPublish from './InsertPublish'
+
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+const mockNavigate = jest.fn()
+
+jest.mock('@/assets/css/insertPublish.css', () => ({}), { virtual: true })
+jest.mock('@/assets/css/audioDesc.css', () => ({}), { virtual: true })
+jest.mock('@/assets/css/editAudioDesc.css', () => ({}), { virtual: true })
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}))
+
+jest.mock(
+  '@/App',
+  () => ({
+    userDataStore: {
+      getState: () => ({
+        userId: 'user-1',
+      }),
+    },
+  }),
+  { virtual: true },
+)
+
+jest.mock('bootstrap', () => ({
+  Tooltip: jest.fn(),
+}))
+
+jest.mock('react-media-recorder', () => ({
+  useReactMediaRecorder: () => ({
+    status: 'idle',
+    startRecording: jest.fn(),
+    stopRecording: jest.fn(),
+    mediaBlobUrl: null,
+    clearBlobUrl: jest.fn(),
+  }),
+}))
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+jest.mock('../../../shared/components/Modal/Modal', () => ({
+  __esModule: true,
+  default: () => <div data-testid="publish-modal" />,
+}))
+
+type Props = React.ComponentProps<typeof InsertPublish>
+
+const buildProps = (overrides: Partial<Props> = {}): Props => ({
+  handleClicksFromParent: '',
+  setHandleClicksFromParent: jest.fn(),
+  seconds: 0,
+  reset: jest.fn(),
+  setShowSpinner: jest.fn(),
+  userId: 'user-1',
+  youtubeVideoId: 'youtube-1',
+  currentTime: 12.5,
+  videoLength: 120,
+  audioDescriptionId: 'ad-1',
+  participantId: 'participant-1',
+  setNeedRefresh: jest.fn(),
+  ...overrides,
+})
+
+const readStartTimeInputs = () =>
+  screen
+    .getAllByRole('spinbutton')
+    .map((input) => Number((input as HTMLInputElement).value))
+
+describe('InsertPublish PR2 insert-time behavior', () => {
+  beforeEach(() => {
+    mockedAxios.post.mockReset()
+    mockNavigate.mockReset()
+    mockedAxios.post.mockResolvedValue({ data: 'saved' })
+  })
+
+  it.each([
+    ['inline', /insert inline audio clip/i],
+    ['extended', /insert extended audio clip/i],
+  ])(
+    'snapshots the current timeline time when parent triggers %s open',
+    async (trigger, heading) => {
+      const setHandleClicksFromParent = jest.fn()
+      const initialProps = buildProps({
+        currentTime: 33.21,
+        handleClicksFromParent: trigger,
+        setHandleClicksFromParent,
+      })
+      const { rerender } = render(<InsertPublish {...initialProps} />)
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: heading }),
+        ).toBeInTheDocument()
+      })
+
+      expect(setHandleClicksFromParent).toHaveBeenCalledWith('')
+      expect(readStartTimeInputs()).toEqual([0, 0, 33, 21])
+
+      rerender(
+        <InsertPublish
+          {...buildProps({
+            ...initialProps,
+            currentTime: 77.89,
+            handleClicksFromParent: '',
+            setHandleClicksFromParent,
+          })}
+        />,
+      )
+
+      expect(readStartTimeInputs()).toEqual([0, 0, 33, 21])
+    },
+  )
+
+  it('snapshots the current timeline time on insert-open and does not drift while the dialog stays open', () => {
+    const initialProps = buildProps({ currentTime: 12.5 })
+    const { rerender } = render(<InsertPublish {...initialProps} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /insert inline/i }))
+
+    expect(readStartTimeInputs()).toEqual([0, 0, 12, 50])
+
+    rerender(
+      <InsertPublish
+        {...buildProps({ ...initialProps, currentTime: 48.75 })}
+      />,
+    )
+
+    expect(readStartTimeInputs()).toEqual([0, 0, 12, 50])
+  })
+
+  it('preserves a user-edited Start Time and submits that value on save', async () => {
+    const initialProps = buildProps({ currentTime: 12.5 })
+    const { rerender } = render(<InsertPublish {...initialProps} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /insert inline/i }))
+
+    const [hours, minutes, seconds, centiseconds] =
+      screen.getAllByRole('spinbutton')
+
+    fireEvent.change(hours, { target: { value: '0' } })
+    fireEvent.change(minutes, { target: { value: '1' } })
+    fireEvent.change(seconds, { target: { value: '2' } })
+    fireEvent.change(centiseconds, { target: { value: '3' } })
+
+    fireEvent.change(screen.getByPlaceholderText(/title goes here/i), {
+      target: { value: 'Inserted clip' },
+    })
+    fireEvent.change(
+      screen.getByPlaceholderText(/start writing a text description/i),
+      {
+        target: { value: 'This is a saved clip description.' },
+      },
+    )
+
+    rerender(
+      <InsertPublish
+        {...buildProps({ ...initialProps, currentTime: 99.99 })}
+      />,
+    )
+
+    expect(readStartTimeInputs()).toEqual([0, 1, 2, 3])
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1)
+    })
+
+    const formData = mockedAxios.post.mock.calls[0][1] as FormData
+
+    expect(formData.get('newACTitle')).toBe('Inserted clip')
+    expect(formData.get('newACStartTime')).toBe('62.03')
+  })
+})

--- a/src/features/Describe/InsertPublish/InsertPublish.tsx
+++ b/src/features/Describe/InsertPublish/InsertPublish.tsx
@@ -49,6 +49,8 @@ const InsertPublish = ({
 
   const openNewAudioClip = useCallback(
     (isInline: boolean) => {
+      // Snapshot the visible timeline label time at open so the dialog does
+      // not drift if playback state changes while the form is open.
       setInsertClipStartTimeSnapshot(currentTime)
       setShowInlineACComponent(isInline)
       setShowNewACComponent(true)

--- a/src/features/Describe/InsertPublish/InsertPublish.tsx
+++ b/src/features/Describe/InsertPublish/InsertPublish.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import '@/assets/css/insertPublish.css'
 import '@/assets/css/audioDesc.css'
 import axios from 'axios'
@@ -44,17 +44,26 @@ const InsertPublish = ({
   const [showNewACComponent, setShowNewACComponent] = useState(false)
   const [isModal, setIsModal] = useState(false)
   const [enrollInCollabEdit, setEnrollInCollabEdit] = useState(true)
+  const [insertClipStartTimeSnapshot, setInsertClipStartTimeSnapshot] =
+    useState(currentTime)
+
+  const openNewAudioClip = useCallback(
+    (isInline: boolean) => {
+      setInsertClipStartTimeSnapshot(currentTime)
+      setShowInlineACComponent(isInline)
+      setShowNewACComponent(true)
+    },
+    [currentTime],
+  )
 
   const handleClickInsertInline = (e: any) => {
     e.preventDefault()
-    setShowNewACComponent(true)
-    setShowInlineACComponent(true)
+    openNewAudioClip(true)
   }
 
   const handleClickInsertExtended = (e: any) => {
     e.preventDefault()
-    setShowNewACComponent(true)
-    setShowInlineACComponent(false)
+    openNewAudioClip(false)
   }
 
   const handleClickPublish = (e: any) => {
@@ -119,15 +128,13 @@ const InsertPublish = ({
 
   useEffect(() => {
     if (handleClicksFromParent === 'inline') {
-      setShowNewACComponent(true)
-      setShowInlineACComponent(true)
       setHandleClicksFromParent('') // reset it back to empty
+      openNewAudioClip(true)
     } else if (handleClicksFromParent === 'extended') {
-      setShowNewACComponent(true)
-      setShowInlineACComponent(false)
       setHandleClicksFromParent('') // reset it back to empty
+      openNewAudioClip(false)
     }
-  }, [handleClicksFromParent, setHandleClicksFromParent])
+  }, [handleClicksFromParent, openNewAudioClip, setHandleClicksFromParent])
 
   return (
     <React.Fragment>
@@ -142,7 +149,7 @@ const InsertPublish = ({
             youtubeVideoId={youtubeVideoId}
             showInlineACComponent={showInlineACComponent}
             setShowNewACComponent={setShowNewACComponent}
-            currentTime={currentTime}
+            initialStartTime={insertClipStartTimeSnapshot}
             videoLength={videoLength}
             audioDescriptionId={audioDescriptionId}
             setShowSpinner={setShowSpinner}

--- a/src/features/Describe/NewAudioClip/NewAudioClip.tsx
+++ b/src/features/Describe/NewAudioClip/NewAudioClip.tsx
@@ -13,7 +13,7 @@ interface Props {
   youtubeVideoId: string
   showInlineACComponent: boolean
   setShowNewACComponent: React.Dispatch<React.SetStateAction<boolean>>
-  currentTime: number
+  initialStartTime: number
   videoLength: number
   audioDescriptionId: string
   setNeedRefresh: React.Dispatch<React.SetStateAction<boolean>>
@@ -25,14 +25,13 @@ const NewAudioClipComponent = ({
   youtubeVideoId,
   showInlineACComponent,
   setShowNewACComponent,
-  currentTime,
+  initialStartTime,
   audioDescriptionId,
   setNeedRefresh,
 }: Props) => {
   const [newACTitle, setNewACTitle] = useState('')
   const [newACType, setNewACType] = useState('Visual')
   const [newACDescriptionText, setNewACDescriptionText] = useState('')
-  const [newACStartTime, setNewACStartTime] = useState(currentTime)
   const [isRecording, setIsRecording] = useState(false)
   const [recordingError, setRecordingError] = useState<string | null>(null)
   const [descriptionMethod, setDescriptionMethod] = useState<'text' | 'audio'>(
@@ -58,8 +57,8 @@ const NewAudioClipComponent = ({
     Array.from(tooltipTriggerList).map(
       (tooltipTriggerEl) => new Tooltip(tooltipTriggerEl),
     )
-    handleClipStartTimeInputsRender()
-  }, [currentTime])
+    handleClipStartTimeInputsRender(initialStartTime)
+  }, [initialStartTime])
 
   const updateRecordingDuration = useCallback(() => {
     setRecordingDuration((prevDuration) => prevDuration + 0.1)
@@ -82,13 +81,12 @@ const NewAudioClipComponent = ({
     }
   }, [status, updateRecordingDuration])
 
-  const handleClipStartTimeInputsRender = () => {
-    const cardFormat = convertSecondsToCardFormat(currentTime).split(':')
+  const handleClipStartTimeInputsRender = (startTime: number) => {
+    const cardFormat = convertSecondsToCardFormat(startTime).split(':')
     setClipStartTimeHours(parseInt(cardFormat[0]))
     setClipStartTimeMinutes(parseInt(cardFormat[1]))
     setClipStartTimeSeconds(parseInt(cardFormat[2]))
     setClipStartTimeCentiseconds(parseInt(cardFormat[3]))
-    setNewACStartTime(currentTime)
   }
 
   // Handle Record Ready Set Go - Match EditClip.tsx exactly
@@ -277,9 +275,6 @@ const NewAudioClipComponent = ({
                             break
                         }
                       }}
-                      onBlur={() =>
-                        setNewACStartTime(calculateClipStartTimeinSeconds())
-                      }
                     />
                   </React.Fragment>
                 ))}

--- a/src/pages/YDXHome.insert-time.test.tsx
+++ b/src/pages/YDXHome.insert-time.test.tsx
@@ -1,0 +1,252 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import axios from 'axios'
+import YDXHome from './YDXHome'
+
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+const mockNavigate = jest.fn()
+const audioDescriptionResponses: any[] = []
+const originalClientWidth = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'clientWidth',
+)
+
+jest.mock('@/assets/css/insertPublish.css', () => ({}), { virtual: true })
+jest.mock('@/assets/css/audioDesc.css', () => ({}), { virtual: true })
+jest.mock('@/assets/css/editAudioDesc.css', () => ({}), { virtual: true })
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({
+    audioDescriptionId: 'ad-1',
+    youtubeVideoId: 'youtube-1',
+  }),
+}))
+
+jest.mock(
+  '@/App',
+  () => ({
+    userDataStore: {
+      getState: () => ({
+        userId: 'user-1',
+      }),
+    },
+  }),
+  { virtual: true },
+)
+
+jest.mock('use-elapsed-time', () => ({
+  useElapsedTime: () => ({
+    elapsedTime: 0,
+  }),
+}))
+
+jest.mock('debounce', () => ({
+  debounce: (fn: (...args: any[]) => unknown) => fn,
+}))
+
+jest.mock('react-youtube', () => ({
+  __esModule: true,
+  default: () => <div data-testid="youtube-player" />,
+}))
+
+jest.mock('react-draggable', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    onStop,
+  }: {
+    children: React.ReactNode
+    onStop?: (event: unknown, data: { x: number; y: number }) => void
+  }) => (
+    <div>
+      {onStop ? (
+        <button
+          type="button"
+          data-testid="master-timeline-stop"
+          onClick={() => onStop({}, { x: 0.1, y: 0 })}
+        >
+          Trigger drag stop
+        </button>
+      ) : null}
+      {children}
+    </div>
+  ),
+}))
+
+jest.mock('../features/Describe/Buttons/Buttons', () => ({
+  Buttons: () => <div data-testid="buttons" />,
+}))
+
+jest.mock('../features/Describe/Notes/Notes', () => ({
+  __esModule: true,
+  default: () => <div data-testid="notes" />,
+}))
+
+jest.mock('../features/Describe/AudioClip/AudioClip', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('../shared/components/Spinner/Spinner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="spinner" />,
+}))
+
+jest.mock('../shared/components/Modal/Modal', () => ({
+  __esModule: true,
+  default: () => <div data-testid="publish-modal" />,
+}))
+
+jest.mock('react-bootstrap/Button', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}))
+
+jest.mock('bootstrap', () => ({
+  Tooltip: jest.fn(),
+}))
+
+jest.mock('react-media-recorder', () => ({
+  useReactMediaRecorder: () => ({
+    status: 'idle',
+    startRecording: jest.fn(),
+    stopRecording: jest.fn(),
+    mediaBlobUrl: null,
+    clearBlobUrl: jest.fn(),
+  }),
+}))
+
+jest.mock('howler', () => {
+  class MockHowl {
+    load = jest.fn()
+    unload = jest.fn()
+    pause = jest.fn()
+    seek = jest.fn()
+    play = jest.fn()
+    once = jest.fn()
+    on = jest.fn()
+    volume = jest.fn()
+    state = jest.fn(() => 'loaded')
+    playing = jest.fn(() => false)
+  }
+
+  return {
+    Howl: MockHowl,
+  }
+})
+
+const makeAudioDescriptionResponse = (clips: any[]) => ({
+  Audio_Clips: clips,
+  Notes: ['Notes'],
+  is_collaborative_version: false,
+  is_published: false,
+})
+
+const queueAudioDescriptionResponses = (...responses: any[]) => {
+  audioDescriptionResponses.length = 0
+  audioDescriptionResponses.push(...responses)
+}
+
+const readStartTimeInputs = () =>
+  screen
+    .getAllByRole('spinbutton')
+    .map((input) => Number((input as HTMLInputElement).value))
+
+describe('YDXHome PR2 insert-time behavior', () => {
+  beforeEach(() => {
+    audioDescriptionResponses.length = 0
+    mockedAxios.get.mockReset()
+    mockedAxios.post.mockReset()
+    mockNavigate.mockReset()
+    localStorage.clear()
+    sessionStorage.clear()
+
+    mockedAxios.get.mockImplementation((url) => {
+      if (url.includes('/api/videos/get-by-youtubeVideo/')) {
+        return Promise.resolve({
+          data: {
+            video_id: 'video-1',
+            video_length: 120,
+          },
+        })
+      }
+
+      if (url.includes('/api/dialog-timestamps/get-video-dialog/')) {
+        return Promise.resolve({
+          data: [],
+        })
+      }
+
+      if (url.includes('/api/audio-descriptions/get-user-ad/')) {
+        const nextResponse =
+          audioDescriptionResponses.length > 1
+            ? audioDescriptionResponses.shift()
+            : audioDescriptionResponses[0]
+
+        if (!nextResponse) {
+          throw new Error(`Missing audio description response for ${url}`)
+        }
+
+        return Promise.resolve({
+          data: nextResponse,
+        })
+      }
+
+      throw new Error(`Unexpected axios.get URL: ${url}`)
+    })
+
+    mockedAxios.post.mockResolvedValue({ data: 'saved' })
+
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 1,
+    })
+  })
+
+  afterAll(() => {
+    if (originalClientWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'clientWidth',
+        originalClientWidth,
+      )
+    }
+  })
+
+  it('syncs the drag-stop time before insert-open snapshots the master timeline value', async () => {
+    queueAudioDescriptionResponses(makeAudioDescriptionResponse([]))
+
+    render(<YDXHome />)
+
+    await screen.findByRole('button', { name: /insert inline/i })
+
+    fireEvent.click(screen.getByTestId('master-timeline-stop'))
+
+    await waitFor(() => {
+      expect(screen.getByText('00:00:12:50')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /insert inline/i }))
+
+    expect(readStartTimeInputs()).toEqual([0, 0, 12, 50])
+  })
+})

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -1109,6 +1109,8 @@ const YDXHome = (): React.ReactElement => {
     setDraggableTime({ x: position.x, y: 0 })
     let progressBarTime = 0.0
     progressBarTime = position.x / unitLength
+    setCurrentTime(progressBarTime)
+    currentTimeRef.current = progressBarTime
     currentEventRef.current?.seekTo(progressBarTime, true)
     const currentPlayerTime = await currentEventRef.current?.getCurrentTime()
     setPreviousTime(currentPlayerTime ?? 0)

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -1109,6 +1109,8 @@ const YDXHome = (): React.ReactElement => {
     setDraggableTime({ x: position.x, y: 0 })
     let progressBarTime = 0.0
     progressBarTime = position.x / unitLength
+    // Keep the visible label in sync with the final drag-stop position before
+    // insert-open snapshots currentTime for a new clip.
     setCurrentTime(progressBarTime)
     currentTimeRef.current = progressBarTime
     currentEventRef.current?.seekTo(progressBarTime, true)


### PR DESCRIPTION
## TL;DR

This PR is the second PR in a stacked sequence for the editor playback/save issues.
It fixes insert Start Time correctness only: when the insert dialog opens, it snapshots the visible master timeline time once, keeps that value stable while the dialog is open, preserves user edits as the final saved Start Time, and syncs drag-stop before snapshotting.

## Description

This is a stacked PR on top of `joo/clip-refresh-fix` and should be reviewed against that parent branch, not `dev`.

This PR fixes the insert flow so the Start Time is snapshotted when the insert dialog opens, instead of continuing to follow live playback time while the dialog remains open.

Specifically, this PR:
- preserves a user-edited Start Time and submits that edited value on save
- syncs the master timeline time on drag stop before the insert snapshot is taken
- adds targeted PR2 tests for the insert Start Time snapshot flow
- does not change PR1 save-refresh rebuild behavior.

## Key changes

- snapshot the visible master timeline time when insert opens
- pass that snapshot into the insert dialog as the initial Start Time
- freeze the initial Start Time while the dialog remains open
- preserve user-edited Start Time as the value submitted on save
- sync the master timeline time on drag stop before insert-open reads it
- add targeted PR2 tests for direct insert-open and parent-triggered open paths

## Motivation and Context

Previously, the insert dialog was tied too directly to live `currentTime`, so the Start Time could drift while the dialog was open. That made the saved clip start time diverge from what the user saw in the insert card or intended to save.

This PR fixes that by:
- snapshotting the visible master timeline time when insert opens
- freezing that initial value inside the insert form
- keeping user edits authoritative for the final saved Start Time
- making drag-stop update the visible timeline time before insert-open reads it

## How has this been tested?

Automated tests:
- `CI=true npm test -- --runTestsByPath src/features/Describe/InsertPublish/InsertPublish.test.tsx src/pages/YDXHome.insert-time.test.tsx --watchAll=false`
- `./node_modules/.bin/eslint src/features/Describe/InsertPublish/InsertPublish.test.tsx src/pages/YDXHome.insert-time.test.tsx`

Covered cases:
- insert-open seeds Start Time from the visible timeline time
- Start Time does not drift while the dialog is open
- user-edited Start Time is preserved and used for save
- drag-stop syncs the final position before insert-open snapshots it
- parent-triggered open path snapshots the same way as the direct insert flow

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.