### PR TITLE
feat: per-clip speed control, Notes export-to-clips, compact EditClip UI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 stages:
+  - validate
   - build
   - deploy
   - cleanup
@@ -9,6 +10,7 @@ variables:
   CI_REGISTRY: docker.io
   IMAGE_NAME: "${DOCKER_REGISTRY}/${CI_PROJECT_NAME}"
   LATEST_IMAGE: "${IMAGE_NAME}:latest"
+  BRANCH_IMAGE: "${IMAGE_NAME}:${CI_COMMIT_REF_SLUG}"
 
 services:
   - docker:24.0.5-dind
@@ -18,6 +20,33 @@ before_script:
   - docker-compose --version
   - echo "Logging into Docker..."
   - echo "$DOCKER_REGISTRY_PASSWORD" | docker login -u "$DOCKER_REGISTRY_USER" --password-stdin $CI_REGISTRY
+
+validate_branch:
+  stage: validate
+  variables:
+    REACT_APP_REDIRECT_URL: $REACT_APP_REDIRECT_URL_DEV
+    REACT_APP_YDX_BACKEND_URL: $REACT_APP_YDX_BACKEND_URL_DEV
+    REACT_APP_YOUTUBE_API_URL: $REACT_APP_YOUTUBE_API_URL_DEV
+    REACT_APP_YOUTUBE_API_KEY: $REACT_APP_YOUTUBE_API_KEY_DEV
+  script:
+    - echo "Validating feature branch pipeline for $CI_COMMIT_BRANCH"
+    - docker build
+      --build-arg REACT_APP_REDIRECT_URL="$REACT_APP_REDIRECT_URL"
+      --build-arg REACT_APP_YDX_BACKEND_URL="$REACT_APP_YDX_BACKEND_URL"
+      --build-arg REACT_APP_YOUTUBE_API_URL="$REACT_APP_YOUTUBE_API_URL"
+      --build-arg REACT_APP_YOUTUBE_API_KEY="$REACT_APP_YOUTUBE_API_KEY"
+      --build-arg REACT_APP_LOGROCKET_ID="$REACT_APP_LOGROCKET_ID"
+      --build-arg REACT_APP_GOOGLE_CLIENT_ID="$REACT_APP_GOOGLE_CLIENT_ID"
+      --build-arg REACT_APP_USE_YDX="$REACT_APP_USE_YDX"
+      --build-arg REACT_APP_CLASSIC_BACKEND_URL="$REACT_APP_CLASSIC_BACKEND_URL"
+      --build-arg REACT_APP_CLASSIC_BACKEND_URL_VERSION="$REACT_APP_CLASSIC_BACKEND_URL_VERSION"
+      -t $BRANCH_IMAGE .
+    - echo "Validation build complete. Open an MR and get Sanjay's review before merging to dev."
+  tags:
+    - frontend
+    - dev
+  rules:
+    - if: '$CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH != "dev" && $CI_COMMIT_BRANCH != "main"'
 
 .build_template: &build_template
   stage: build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+## Branch And Merge Flow
+
+1. Do all implementation work on your own personal branch.
+2. Before any merge happens, Sanjay must complete code review.
+3. After Sanjay approves, merge the change into `dev`.
+4. Once the code is in `dev`, the whole team tests it together. This testing step is shared by everyone, including the original author.
+5. Only after the `dev` branch has been tested thoroughly and looks good should the change be merged into `main`.
+
+## CI/CD Expectations
+
+- Personal branches run validation only. They should not deploy.
+- The `dev` branch is the shared integration branch for team testing.
+- The `main` branch is production-only and should receive code only after `dev` testing is complete.
+
+## Review Policy
+
+The CI pipeline can validate branches and deployments, but reviewer identity enforcement must be configured in GitLab project settings.
+Set merge request approvals so Sanjay must approve before merges into `dev` or `main`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -215,6 +215,10 @@ const App = () => {
           })
           const data = await response.json()
 
+          if (!response.ok || !data?.result) {
+            throw new Error(data?.message || 'Local development login failed')
+          }
+
           setUserData(data.result)
           handleRedirect()
         }
@@ -223,6 +227,10 @@ const App = () => {
           credentials: 'include',
         })
         const data = await response.json()
+
+        if (!response.ok || !data?.result) {
+          throw new Error(data?.message || 'Login failed')
+        }
 
         setUserData(data.result)
         handleRedirect()
@@ -234,11 +242,15 @@ const App = () => {
 
   // New helper function to set user data
   const setUserData = (result: any) => {
+    if (!result) {
+      throw new Error('No user data returned from login')
+    }
+
     setUserName(result.name)
     setUserId(result._id)
     setUserToken(result.token)
     setUserPicture(result.picture)
-    setUserAdmin(result.admin)
+    setUserAdmin(result.admin ?? result.admin_level ?? 0)
     setSignedIn(true)
     setCookie(result._id, result.token, result.name, result.picture)
   }

--- a/src/assets/css/audioDesc.css
+++ b/src/assets/css/audioDesc.css
@@ -427,3 +427,34 @@
 .spacing-loose {
   gap: var(--space-md);
 }
+
+/* Per-clip speed buttons (in AudioClip card header) */
+.speed-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+  border-left: 1px solid var(--border-primary);
+  padding-left: 10px;
+  margin-left: 4px;
+}
+.speed-btn {
+  padding: 2px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #222;
+}
+.speed-btn.active {
+  background: var(--primary-color, #0d6efd);
+  color: #fff;
+  border-color: var(--primary-color, #0d6efd);
+}
+.speed-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}

--- a/src/assets/css/editAudioDesc.css
+++ b/src/assets/css/editAudioDesc.css
@@ -11,8 +11,8 @@
 .edit-component {
   background-color: var(--background-tertiary);
   border-radius: var(--radius-lg);
-  padding: var(--space-sm) var(--space-md); /* Further reduced padding */
-  margin-top: var(--space-lg);
+  padding: var(--space-xs) var(--space-sm);
+  margin-top: var(--space-sm);
   border: 1px solid var(--border-primary);
   box-shadow: var(--shadow-md);
 
@@ -64,19 +64,19 @@
 }
 
 .audio-mode-icon {
-  font-size: var(--text-xl); /* Increased font size */
+  font-size: var(--text-sm);
   padding: var(--space-xs);
   background-color: rgba(255, 255, 255, 0.2);
   border-radius: var(--radius-sm);
 }
 
 .audio-mode-title {
-  font-size: var(--text-xl); /* Increased font size */
+  font-size: var(--text-xs);
   font-weight: 600;
 }
 
 .audio-mode-description {
-  font-size: var(--text-base); /* Increased font size */
+  font-size: var(--text-xs);
   opacity: 0.9;
   font-style: italic;
 }
@@ -111,14 +111,14 @@
 }
 
 .section-title {
-  font-size: var(--text-2xl); /* Increased font size */
+  font-size: var(--text-xs);
   font-weight: 600;
   color: var(--text-primary);
   margin: 0;
 }
 
 .description-status {
-  font-size: var(--text-base); /* Increased font size */
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   font-weight: 500;
 }
@@ -128,11 +128,11 @@
   border: 2px solid var(--border-primary);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: var(--text-2xl); /* Increased font size */
-  line-height: 1.6;
-  padding: var(--space-xs) var(--space-sm); /* Further reduced padding */
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  padding: var(--space-xs) var(--space-sm);
   resize: vertical;
-  min-height: 100px;
+  min-height: 72px;
   transition: all var(--duration-fast) ease;
   width: 100%;
   font-family: inherit;

--- a/src/assets/css/notes.css
+++ b/src/assets/css/notes.css
@@ -7,16 +7,14 @@
   height: 265px;
 }
 .notes-label {
-  margin-bottom: -5px;
+  margin-bottom: 0;
+  padding-bottom: 4px;
 }
 .notes-textarea-div {
   background-color: white;
   width: 400px;
-  height: 232px;
-  overflow-y: scroll;
-}
-.notes-textarea {
-  resize: none;
+  height: 195px;
+  overflow-y: auto;
 }
 .notes-save-btn {
   padding-left: 3px;

--- a/src/features/Describe/AudioClip/AudioClip.tsx
+++ b/src/features/Describe/AudioClip/AudioClip.tsx
@@ -511,13 +511,19 @@ const AudioClip = ({
               </div>
 
               {/* Per-clip playback speed */}
-              <div className="speed-buttons" role="group" aria-label="Clip playback speed">
+              <div
+                className="speed-buttons"
+                role="group"
+                aria-label="Clip playback speed"
+              >
                 <span className="speed-label">Speed:</span>
-                {SPEED_OPTIONS.map(speed => (
+                {SPEED_OPTIONS.map((speed) => (
                   <button
                     key={speed}
                     type="button"
-                    className={`speed-btn${clipSpeed === speed ? ' active' : ''}`}
+                    className={`speed-btn${
+                      clipSpeed === speed ? ' active' : ''
+                    }`}
                     onClick={() => handleSpeedChange(speed)}
                     aria-pressed={clipSpeed === speed}
                     aria-label={`Set speed to ${speed}x`}

--- a/src/features/Describe/AudioClip/AudioClip.tsx
+++ b/src/features/Describe/AudioClip/AudioClip.tsx
@@ -113,6 +113,21 @@ const AudioClip = ({
   const [clipPlaybackType, setClipPlayBackType] = useState('')
   const [clipTitle, setClipTitle] = useState('')
   const [clipStartTime, setClipStartTime] = useState(0)
+  const [clipSpeed, setClipSpeed] = useState(clip.clip_speed ?? 1)
+  const SPEED_OPTIONS = [0.75, 1, 1.25, 1.5, 2]
+
+  const handleSpeedChange = async (speed: number) => {
+    setClipSpeed(speed)
+    try {
+      await axios.put(
+        `${process.env.REACT_APP_YDX_BACKEND_URL}/api/audio-clips/update-clip-speed/${clipID}`,
+        { speed },
+      )
+    } catch {
+      toast.error('Failed to update speed.')
+      setClipSpeed(clipSpeed)
+    }
+  }
 
   // Toggle variable to show or hide the edit component
   const [showEditComponent, setShowEditComponent] = useState(false)
@@ -286,7 +301,7 @@ const AudioClip = ({
       if (updatedClipDescriptionText !== initialclipDescriptionText) {
         setShowSpinner(true)
 
-        await axios.put(
+        const response = await axios.put(
           `${process.env.REACT_APP_YDX_BACKEND_URL}/api/audio-clips/update-clip-description/${clipID}`,
           {
             userId: userId,
@@ -299,6 +314,7 @@ const AudioClip = ({
 
         setUpdateData(!updateData)
         toast.success('Description saved successfully!')
+        return response.data
       }
 
       // Handle title updates separately
@@ -314,6 +330,8 @@ const AudioClip = ({
           },
         )
       }
+
+      return null
     } catch (err: any) {
       if (err.response) {
         toast.error(err.response.data.message)
@@ -375,10 +393,6 @@ const AudioClip = ({
               <div>
                 <strong>Duration:</strong>{' '}
                 {convertSecondsToCardFormat(clipDuration)}
-              </div>
-              <div className="description-preview">
-                {descriptionDisplay.substring(0, 60)}
-                {descriptionDisplay.length > 60 ? '...' : ''}
               </div>
             </div>
           </div>
@@ -495,6 +509,23 @@ const AudioClip = ({
                   <span className="inline-extended-label">Extended</span>
                 </label>
               </div>
+
+              {/* Per-clip playback speed */}
+              <div className="speed-buttons" role="group" aria-label="Clip playback speed">
+                <span className="speed-label">Speed:</span>
+                {SPEED_OPTIONS.map(speed => (
+                  <button
+                    key={speed}
+                    type="button"
+                    className={`speed-btn${clipSpeed === speed ? ' active' : ''}`}
+                    onClick={() => handleSpeedChange(speed)}
+                    aria-pressed={clipSpeed === speed}
+                    aria-label={`Set speed to ${speed}x`}
+                  >
+                    {speed}x
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
 
@@ -563,6 +594,7 @@ const AudioClip = ({
             handleClickSaveClipDescription={handleClickSaveClipDescription}
             setUndoDeletedClip={setUndoDeletedClip}
             setClipDescText={handleDescriptionChange}
+            clipSpeed={clipSpeed}
           />
         )}
       </div>

--- a/src/features/Describe/Buttons/Buttons.tsx
+++ b/src/features/Describe/Buttons/Buttons.tsx
@@ -10,6 +10,8 @@ interface Props {
   setDescriptionVolume: (value: number) => void
   youTubeVolume: number
   setYouTubeVolume: (value: number) => void
+  playbackSpeed: number
+  setPlaybackSpeed: (value: number) => void
   isPreviewAudioDescription?: boolean
 }
 
@@ -21,6 +23,8 @@ export const Buttons = ({
   setDescriptionVolume,
   youTubeVolume,
   setYouTubeVolume,
+  playbackSpeed,
+  setPlaybackSpeed,
   isPreviewAudioDescription = false,
 }: Props) => {
   return (
@@ -66,6 +70,8 @@ export const Buttons = ({
             setDescriptionVolume={setDescriptionVolume}
             youTubeVideoVolume={youTubeVolume}
             setYouTubeVideoVolume={setYouTubeVolume}
+            playbackSpeed={playbackSpeed}
+            setPlaybackSpeed={setPlaybackSpeed}
           />
         </div>
       </div>

--- a/src/features/Describe/EditClip/EditClip.tsx
+++ b/src/features/Describe/EditClip/EditClip.tsx
@@ -11,6 +11,7 @@ import { YouTubePlayer } from 'youtube-player/dist/types'
 import convertSecondsToCardFormat from '../../../shared/utils/convertSecondsToCardFormat'
 import padNumber from '@/shared/utils/padNumber'
 import { Tooltip } from 'bootstrap'
+import getBlobAudioDuration from '@/shared/utils/getBlobAudioDuration'
 
 interface Props {
   userId: string
@@ -37,8 +38,11 @@ interface Props {
   setNeedRefresh: React.Dispatch<React.SetStateAction<boolean>>
   setUndoDeletedClip: React.Dispatch<React.SetStateAction<boolean>>
   isPreview?: boolean
-  handleClickSaveClipDescription: (updatedClipDescriptionText: string) => void
+  handleClickSaveClipDescription: (
+    updatedClipDescriptionText: string,
+  ) => Promise<any>
   setClipDescText: (description: string) => void
+  clipSpeed?: number
 }
 
 const EditClip = ({
@@ -68,6 +72,7 @@ const EditClip = ({
   handleClickSaveClipDescription,
   setUndoDeletedClip,
   setClipDescText,
+  clipSpeed: initialClipSpeed = 1,
 }: Props) => {
   const ref = useRef<HTMLDivElement>(null)
   const clipEndTime = clipStartTime + clipDuration
@@ -79,6 +84,8 @@ const EditClip = ({
   const [recordedClipDuration, setRecordedClipDuration] = useState(0.0)
   const [readySetGo, setReadySetGo] = useState('')
   const [isDeleteModal, setIsDeleteModal] = useState(false)
+
+  const clipSpeed = initialClipSpeed
 
   // Audio playback state management
   const [recordedAudio, setRecordedAudio] = useState<HTMLAudioElement>()
@@ -119,6 +126,32 @@ const EditClip = ({
   }, [])
 
   const clipDurationAsTimestamp = convertSecondsToCardFormat(clipDuration)
+
+  const getDescriptionPlaybackSpeed = useCallback(
+    () => parseFloat(localStorage.getItem('playbackSpeed') || '1'),
+    [],
+  )
+
+  const buildPlayableAudioUrl = useCallback((audioPath: string) => {
+    if (!audioPath) {
+      return ''
+    }
+
+    let normalizedPath = audioPath
+    if (audioPath.startsWith('.')) {
+      normalizedPath = audioPath.replace(
+        '.',
+        `${process.env.REACT_APP_YDX_BACKEND_URL}/api/static`,
+      )
+    } else if (audioPath.startsWith('/')) {
+      normalizedPath = `${process.env.REACT_APP_YDX_BACKEND_URL}/api/static${audioPath}`
+    } else if (!audioPath.startsWith('http')) {
+      normalizedPath = `${process.env.REACT_APP_YDX_BACKEND_URL}/api/static/${audioPath}`
+    }
+
+    const separator = normalizedPath.includes('?') ? '&' : '?'
+    return `${normalizedPath}${separator}t=${Date.now()}`
+  }, [])
 
   const getAudioModeDisplay = (isRecorded: boolean, hasText: boolean) => {
     if (isRecorded) {
@@ -240,37 +273,25 @@ const EditClip = ({
     )
 
     // Setup audio playback when new recording is available
-    if (mediaBlobUrl !== null) {
+    if (mediaBlobUrl) {
       const newAudio = new Audio(mediaBlobUrl)
       setRecordedAudio(newAudio)
+      const recordedBlobUrl = mediaBlobUrl
 
       // Calculate and set recorded audio duration
-      newAudio.addEventListener(
-        'loadedmetadata',
-        function () {
-          if (newAudio.duration === Infinity) {
-            // Handle edge case for some audio formats
-            newAudio.currentTime = 1e101
-            newAudio.ontimeupdate = function () {
-              this.ontimeupdate = () => {
-                return
-              }
-              const browserDuration =
-                Math.round(newAudio.duration * 1000) / 1000
-              setRecordedClipDuration(browserDuration)
-              newAudio.currentTime = 0
-            }
-          } else {
-            const browserDuration = Math.round(newAudio.duration * 1000) / 1000
-            setRecordedClipDuration(browserDuration)
-          }
-        },
-        false,
-      )
+      getBlobAudioDuration(recordedBlobUrl)
+        .then((browserDuration) => {
+          setRecordedClipDuration(browserDuration)
+        })
+        .catch(() => {
+          toast.error('Unable to read recorded audio duration.')
+        })
     }
 
     // Setup existing audio clip playback
-    setAdAudio(new Audio(clipAudioPath))
+    if (clipAudioPath) {
+      setAdAudio(new Audio(clipAudioPath))
+    }
   }, [
     clipAudioPath,
     clipCreatedAt,
@@ -511,6 +532,9 @@ const EditClip = ({
       recordedAudio?.pause()
       setIsRecordedAudioPlaying(false)
     } else {
+      if (recordedAudio) {
+        recordedAudio.playbackRate = clipSpeed
+      }
       recordedAudio?.play()
       setIsRecordedAudioPlaying(true)
       recordedAudio?.addEventListener('ended', function () {
@@ -524,6 +548,9 @@ const EditClip = ({
       adAudio?.pause()
       setIsAdAudioPlaying(false)
     } else {
+      if (adAudio) {
+        adAudio.playbackRate = clipSpeed
+      }
       const audioProm = adAudio?.play()
       if (audioProm !== undefined) {
         audioProm
@@ -566,7 +593,7 @@ const EditClip = ({
     }, 3700)
   }
 
-  const saveClipDescription = (e: any) => {
+  const saveClipDescription = async (e: any) => {
     e.preventDefault()
 
     // Get the current button configuration to determine what action to take
@@ -581,7 +608,15 @@ const EditClip = ({
       handleReadySetGo()
     } else {
       // Normal save operation
-      handleClickSaveClipDescription(clipDescriptionText)
+      const updatedClip = await handleClickSaveClipDescription(
+        clipDescriptionText,
+      )
+
+      if (updatedClip?.clip_audio_path && !isRecorded) {
+        adAudio?.pause()
+        setIsAdAudioPlaying(false)
+        setAdAudio(new Audio(buildPlayableAudioUrl(updatedClip.clip_audio_path)))
+      }
     }
   }
 

--- a/src/features/Describe/EditClip/EditClip.tsx
+++ b/src/features/Describe/EditClip/EditClip.tsx
@@ -615,7 +615,9 @@ const EditClip = ({
       if (updatedClip?.clip_audio_path && !isRecorded) {
         adAudio?.pause()
         setIsAdAudioPlaying(false)
-        setAdAudio(new Audio(buildPlayableAudioUrl(updatedClip.clip_audio_path)))
+        setAdAudio(
+          new Audio(buildPlayableAudioUrl(updatedClip.clip_audio_path)),
+        )
       }
     }
   }

--- a/src/features/Describe/NewAudioClip/NewAudioClip.tsx
+++ b/src/features/Describe/NewAudioClip/NewAudioClip.tsx
@@ -6,6 +6,7 @@ import '@/assets/css/editAudioDesc.css'
 import { toast } from 'react-toastify'
 import axios from 'axios'
 import { Tooltip } from 'bootstrap'
+import getBlobAudioDuration from '@/shared/utils/getBlobAudioDuration'
 
 interface Props {
   setShowSpinner: React.Dispatch<React.SetStateAction<boolean>>
@@ -171,8 +172,9 @@ const NewAudioClipComponent = ({
     } else {
       formData.append('newACDescriptionText', '')
       const audioBlob = await fetch(mediaBlobUrl!).then((r) => r.blob())
+      const actualRecordingDuration = await getBlobAudioDuration(mediaBlobUrl!)
       formData.append('file', audioBlob, 'recorded_audio.webm')
-      formData.append('newACDuration', String(recordingDuration))
+      formData.append('newACDuration', String(actualRecordingDuration))
     }
 
     try {

--- a/src/features/Describe/Notes/Notes.tsx
+++ b/src/features/Describe/Notes/Notes.tsx
@@ -17,7 +17,7 @@ interface ImportEntry extends NoteItem {
 }
 
 interface Props {
-  currentTime: string   // HH:MM:SS:MS from parent
+  currentTime: string // HH:MM:SS:MS from parent
   audioDescriptionId: string
   notesData: any
   handleVideoPause: () => void
@@ -31,7 +31,8 @@ const genId = () => Math.random().toString(36).slice(2, 9)
 // HH:MM:SS:MS → seconds
 const parseCurrentTime = (time: string): number => {
   const parts = time.split(':').map(Number)
-  if (parts.length === 4) return parts[0] * 3600 + parts[1] * 60 + parts[2] + parts[3] / 100
+  if (parts.length === 4)
+    return parts[0] * 3600 + parts[1] * 60 + parts[2] + parts[3] / 100
   if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
   return 0
 }
@@ -41,13 +42,14 @@ const formatTime = (secs: number): string => {
   const h = Math.floor(secs / 3600)
   const m = Math.floor((secs % 3600) / 60)
   const s = Math.floor(secs % 60)
-  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+  if (h > 0)
+    return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
   return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
 }
 
 // user-typed MM:SS or H:MM:SS → seconds
 const parseDisplayTime = (display: string): number => {
-  const parts = display.split(':').map(n => parseInt(n) || 0)
+  const parts = display.split(':').map((n) => parseInt(n) || 0)
   if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
   if (parts.length === 2) return parts[0] * 60 + parts[1]
   return 0
@@ -58,19 +60,30 @@ const deserializeNotes = (text: string): NoteItem[] => {
   try {
     const parsed = JSON.parse(text)
     if (Array.isArray(parsed)) {
-      return parsed.map(item => ({
+      return parsed.map((item) => ({
         id: item.id || genId(),
-        timeSeconds: item.timeSeconds ?? parseCurrentTime(item.time || '00:00:00:00'),
+        timeSeconds:
+          item.timeSeconds ?? parseCurrentTime(item.time || '00:00:00:00'),
         text: item.text ?? item.note ?? '',
       }))
     }
-  } catch {}
+  } catch (_e) {
+    // ignore parse errors, fall through to legacy format
+  }
   // Legacy line-by-line format: HH:MM:SS:MS - text
-  return text.split(/\r?\n/).filter(l => l.trim()).map(line => {
-    const match = line.match(/^(\d{2}:\d{2}:\d{2}(?::\d{2})?)\s*-\s*(.*)$/)
-    if (match) return { id: genId(), timeSeconds: parseCurrentTime(match[1]), text: match[2].trim() }
-    return { id: genId(), timeSeconds: 0, text: line.trim() }
-  })
+  return text
+    .split(/\r?\n/)
+    .filter((l) => l.trim())
+    .map((line) => {
+      const match = line.match(/^(\d{2}:\d{2}:\d{2}(?::\d{2})?)\s*-\s*(.*)$/)
+      if (match)
+        return {
+          id: genId(),
+          timeSeconds: parseCurrentTime(match[1]),
+          text: match[2].trim(),
+        }
+      return { id: genId(), timeSeconds: 0, text: line.trim() }
+    })
 }
 
 const serializeNotes = (notes: NoteItem[]): string => JSON.stringify(notes)
@@ -99,7 +112,7 @@ const Notes = ({
         notes: serializeNotes(current),
         adId: audioDescriptionId,
       })
-      .then(res => setNoteId(res.data.notes_id))
+      .then((res) => setNoteId(res.data.notes_id))
       .catch(() => toast.error('Error saving note!'))
   }
 
@@ -115,23 +128,28 @@ const Notes = ({
 
   const handleAddNote = () => {
     handleVideoPause()
-    const newItem: NoteItem = { id: genId(), timeSeconds: parseCurrentTime(currentTime), text: '' }
+    const newItem: NoteItem = {
+      id: genId(),
+      timeSeconds: parseCurrentTime(currentTime),
+      text: '',
+    }
     const updated = [...notes, newItem]
     setNotes(updated)
     debouncedSave(updated)
     // Focus the new text input after render
     setTimeout(() => {
-      const inputs = document.querySelectorAll<HTMLInputElement>('.note-text-input')
+      const inputs =
+        document.querySelectorAll<HTMLInputElement>('.note-text-input')
       inputs[inputs.length - 1]?.focus()
     }, 50)
   }
 
   const handleChangeText = (id: string, text: string) => {
-    updateNotes(notes.map(n => n.id === id ? { ...n, text } : n))
+    updateNotes(notes.map((n) => (n.id === id ? { ...n, text } : n)))
   }
 
   const handleDelete = (id: string) => {
-    updateNotes(notes.filter(n => n.id !== id))
+    updateNotes(notes.filter((n) => n.id !== id))
   }
 
   const handleTimeClick = (note: NoteItem) => {
@@ -141,24 +159,33 @@ const Notes = ({
 
   const handleTimeBlur = (id: string) => {
     const secs = parseDisplayTime(editingTimeValue)
-    updateNotes(notes.map(n => n.id === id ? { ...n, timeSeconds: secs } : n))
+    updateNotes(
+      notes.map((n) => (n.id === id ? { ...n, timeSeconds: secs } : n)),
+    )
     setEditingTimeId(null)
   }
 
   const handleOpenExport = () => {
     const entries = notes
-      .filter(n => n.text.trim())
-      .map(n => ({ ...n, playbackType: 'inline' as const, selected: true }))
-    if (entries.length === 0) { toast.info('No notes to export.'); return }
+      .filter((n) => n.text.trim())
+      .map((n) => ({ ...n, playbackType: 'inline' as const, selected: true }))
+    if (entries.length === 0) {
+      toast.info('No notes to export.')
+      return
+    }
     setExportEntries(entries)
     setShowExportModal(true)
   }
 
   const handleExportConfirm = async () => {
-    const selected = exportEntries.filter(e => e.selected && e.text.trim())
-    if (selected.length === 0) { toast.info('No entries selected.'); return }
+    const selected = exportEntries.filter((e) => e.selected && e.text.trim())
+    if (selected.length === 0) {
+      toast.info('No entries selected.')
+      return
+    }
     setIsExporting(true)
-    let ok = 0, fail = 0
+    let ok = 0,
+      fail = 0
     for (const entry of selected) {
       try {
         const formData = new FormData()
@@ -176,11 +203,16 @@ const Notes = ({
           formData,
         )
         ok++
-      } catch { fail++ }
+      } catch {
+        fail++
+      }
     }
     setIsExporting(false)
     setShowExportModal(false)
-    if (ok > 0) { toast.success(`Exported ${ok} clip${ok > 1 ? 's' : ''}!`); onClipsImported?.() }
+    if (ok > 0) {
+      toast.success(`Exported ${ok} clip${ok > 1 ? 's' : ''}!`)
+      onClipsImported?.()
+    }
     if (fail > 0) toast.error(`${fail} clip${fail > 1 ? 's' : ''} failed.`)
   }
 
@@ -199,7 +231,10 @@ const Notes = ({
       {/* Header */}
       <div className="d-flex justify-content-between align-items-center pt-1 px-3 notes-label">
         <h6 className="text-white">Notes:</h6>
-        <button className="btn btn-sm btn-outline-light" onClick={handleOpenExport}>
+        <button
+          className="btn btn-sm btn-outline-light"
+          onClick={handleOpenExport}
+        >
           Export to Clips
         </button>
       </div>
@@ -207,18 +242,20 @@ const Notes = ({
       {/* Notes list */}
       <div className="notes-textarea-div px-2 py-1">
         {notes.length === 0 && (
-          <p className="text-muted small mt-2 px-1">Click "+ Add note" to start.</p>
+          <p className="text-muted small mt-2 px-1">
+            Click &quot;+ Add note&quot; to start.
+          </p>
         )}
-        {notes.map(note => (
+        {notes.map((note) => (
           <div key={note.id} className="d-flex align-items-center gap-1 mb-1">
             {/* Time badge / editable input */}
             {editingTimeId === note.id ? (
               <input
                 type="text"
                 value={editingTimeValue}
-                onChange={e => setEditingTimeValue(e.target.value)}
+                onChange={(e) => setEditingTimeValue(e.target.value)}
                 onBlur={() => handleTimeBlur(note.id)}
-                onKeyDown={e => e.key === 'Enter' && handleTimeBlur(note.id)}
+                onKeyDown={(e) => e.key === 'Enter' && handleTimeBlur(note.id)}
                 autoFocus
                 style={{
                   width: 60,
@@ -258,7 +295,7 @@ const Notes = ({
               type="text"
               className="note-text-input"
               value={note.text}
-              onChange={e => handleChangeText(note.id, e.target.value)}
+              onChange={(e) => handleChangeText(note.id, e.target.value)}
               placeholder="Note..."
               style={{
                 flex: 1,
@@ -274,9 +311,14 @@ const Notes = ({
             <button
               onClick={() => handleDelete(note.id)}
               style={{
-                background: 'none', border: 'none', color: '#aaa',
-                cursor: 'pointer', fontSize: 16, lineHeight: 1,
-                padding: '0 2px', flexShrink: 0,
+                background: 'none',
+                border: 'none',
+                color: '#aaa',
+                cursor: 'pointer',
+                fontSize: 16,
+                lineHeight: 1,
+                padding: '0 2px',
+                flexShrink: 0,
               }}
               aria-label="Delete note"
             >
@@ -288,30 +330,48 @@ const Notes = ({
 
       {/* Add button */}
       <div className="px-3 pb-1 pt-1">
-        <button className="btn btn-sm btn-outline-light w-100" onClick={handleAddNote}>
+        <button
+          className="btn btn-sm btn-outline-light w-100"
+          onClick={handleAddNote}
+        >
           + Add note at current time
         </button>
       </div>
 
       {/* Export modal */}
       {showExportModal && (
-        <div className="modal d-block" tabIndex={-1} style={{ background: 'rgba(0,0,0,0.5)' }}>
+        <div
+          className="modal d-block"
+          tabIndex={-1}
+          style={{ background: 'rgba(0,0,0,0.5)' }}
+        >
           <div className="modal-dialog modal-lg">
             <div className="modal-content">
               <div className="modal-header">
                 <h5 className="modal-title">Export Notes as Clips</h5>
-                <button className="btn-close" onClick={() => setShowExportModal(false)} />
+                <button
+                  className="btn-close"
+                  onClick={() => setShowExportModal(false)}
+                />
               </div>
-              <div className="modal-body" style={{ maxHeight: '60vh', overflowY: 'auto' }}>
+              <div
+                className="modal-body"
+                style={{ maxHeight: '60vh', overflowY: 'auto' }}
+              >
                 <table className="table table-sm">
                   <thead>
                     <tr>
                       <th style={{ width: 40 }}>
                         <input
                           type="checkbox"
-                          checked={exportEntries.every(e => e.selected)}
-                          onChange={ev =>
-                            setExportEntries(exportEntries.map(e => ({ ...e, selected: ev.target.checked })))
+                          checked={exportEntries.every((e) => e.selected)}
+                          onChange={(ev) =>
+                            setExportEntries(
+                              exportEntries.map((e) => ({
+                                ...e,
+                                selected: ev.target.checked,
+                              })),
+                            )
                           }
                         />
                       </th>
@@ -322,28 +382,39 @@ const Notes = ({
                   </thead>
                   <tbody>
                     {exportEntries.map((entry, i) => (
-                      <tr key={entry.id} style={{ opacity: entry.selected ? 1 : 0.45 }}>
+                      <tr
+                        key={entry.id}
+                        style={{ opacity: entry.selected ? 1 : 0.45 }}
+                      >
                         <td>
                           <input
                             type="checkbox"
                             checked={entry.selected}
-                            onChange={ev =>
-                              setExportEntries(exportEntries.map((e, j) =>
-                                j === i ? { ...e, selected: ev.target.checked } : e
-                              ))
+                            onChange={(ev) =>
+                              setExportEntries(
+                                exportEntries.map((e, j) =>
+                                  j === i
+                                    ? { ...e, selected: ev.target.checked }
+                                    : e,
+                                ),
+                              )
                             }
                           />
                         </td>
-                        <td><code>{formatTime(entry.timeSeconds)}</code></td>
+                        <td>
+                          <code>{formatTime(entry.timeSeconds)}</code>
+                        </td>
                         <td>
                           <input
                             type="text"
                             className="form-control form-control-sm"
                             value={entry.text}
-                            onChange={ev =>
-                              setExportEntries(exportEntries.map((e, j) =>
-                                j === i ? { ...e, text: ev.target.value } : e
-                              ))
+                            onChange={(ev) =>
+                              setExportEntries(
+                                exportEntries.map((e, j) =>
+                                  j === i ? { ...e, text: ev.target.value } : e,
+                                ),
+                              )
                             }
                           />
                         </td>
@@ -351,10 +422,19 @@ const Notes = ({
                           <select
                             className="form-select form-select-sm"
                             value={entry.playbackType}
-                            onChange={ev =>
-                              setExportEntries(exportEntries.map((e, j) =>
-                                j === i ? { ...e, playbackType: ev.target.value as 'inline' | 'extended' } : e
-                              ))
+                            onChange={(ev) =>
+                              setExportEntries(
+                                exportEntries.map((e, j) =>
+                                  j === i
+                                    ? {
+                                        ...e,
+                                        playbackType: ev.target.value as
+                                          | 'inline'
+                                          | 'extended',
+                                      }
+                                    : e,
+                                ),
+                              )
                             }
                           >
                             <option value="inline">Inline</option>
@@ -368,13 +448,22 @@ const Notes = ({
               </div>
               <div className="modal-footer">
                 <span className="me-auto text-muted" style={{ fontSize: 13 }}>
-                  {exportEntries.filter(e => e.selected).length} of {exportEntries.length} selected
+                  {exportEntries.filter((e) => e.selected).length} of{' '}
+                  {exportEntries.length} selected
                 </span>
-                <button className="btn btn-secondary" onClick={() => setShowExportModal(false)}>Cancel</button>
+                <button
+                  className="btn btn-secondary"
+                  onClick={() => setShowExportModal(false)}
+                >
+                  Cancel
+                </button>
                 <button
                   className="btn btn-primary"
                   onClick={handleExportConfirm}
-                  disabled={isExporting || exportEntries.filter(e => e.selected).length === 0}
+                  disabled={
+                    isExporting ||
+                    exportEntries.filter((e) => e.selected).length === 0
+                  }
                 >
                   {isExporting ? 'Exporting...' : 'Export'}
                 </button>

--- a/src/features/Describe/Notes/Notes.tsx
+++ b/src/features/Describe/Notes/Notes.tsx
@@ -1,140 +1,388 @@
 import axios from 'axios'
-import React, { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { toast } from 'react-toastify'
 import '@/assets/css/editAudioDesc.css'
 import '@/assets/css/notes.css'
 import { debounce } from 'debounce'
 
+interface NoteItem {
+  id: string
+  timeSeconds: number
+  text: string
+}
+
+interface ImportEntry extends NoteItem {
+  playbackType: 'inline' | 'extended'
+  selected: boolean
+}
+
 interface Props {
-  currentTime: string
+  currentTime: string   // HH:MM:SS:MS from parent
   audioDescriptionId: string
   notesData: any
   handleVideoPause: () => void
+  userId: string
+  youtubeVideoId: string
+  onClipsImported?: () => void
 }
+
+const genId = () => Math.random().toString(36).slice(2, 9)
+
+// HH:MM:SS:MS → seconds
+const parseCurrentTime = (time: string): number => {
+  const parts = time.split(':').map(Number)
+  if (parts.length === 4) return parts[0] * 3600 + parts[1] * 60 + parts[2] + parts[3] / 100
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
+  return 0
+}
+
+// seconds → MM:SS or H:MM:SS
+const formatTime = (secs: number): string => {
+  const h = Math.floor(secs / 3600)
+  const m = Math.floor((secs % 3600) / 60)
+  const s = Math.floor(secs % 60)
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+// user-typed MM:SS or H:MM:SS → seconds
+const parseDisplayTime = (display: string): number => {
+  const parts = display.split(':').map(n => parseInt(n) || 0)
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
+  if (parts.length === 2) return parts[0] * 60 + parts[1]
+  return 0
+}
+
+const deserializeNotes = (text: string): NoteItem[] => {
+  if (!text) return []
+  try {
+    const parsed = JSON.parse(text)
+    if (Array.isArray(parsed)) {
+      return parsed.map(item => ({
+        id: item.id || genId(),
+        timeSeconds: item.timeSeconds ?? parseCurrentTime(item.time || '00:00:00:00'),
+        text: item.text ?? item.note ?? '',
+      }))
+    }
+  } catch {}
+  // Legacy line-by-line format: HH:MM:SS:MS - text
+  return text.split(/\r?\n/).filter(l => l.trim()).map(line => {
+    const match = line.match(/^(\d{2}:\d{2}:\d{2}(?::\d{2})?)\s*-\s*(.*)$/)
+    if (match) return { id: genId(), timeSeconds: parseCurrentTime(match[1]), text: match[2].trim() }
+    return { id: genId(), timeSeconds: 0, text: line.trim() }
+  })
+}
+
+const serializeNotes = (notes: NoteItem[]): string => JSON.stringify(notes)
 
 const Notes = ({
   currentTime,
   audioDescriptionId,
   notesData,
   handleVideoPause,
+  userId,
+  youtubeVideoId,
+  onClipsImported,
 }: Props) => {
-  // React State Variables
-  const [noteValue, setNoteValue] = useState('') // to store Notes text
-  const [noteId, setNoteId] = useState('') // to store Note Id - for POST requests later
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [noteDetails, setNoteDetails] = useState<any[]>([]) // to store Notes Details
+  const [notes, setNotes] = useState<NoteItem[]>([])
+  const [noteId, setNoteId] = useState('')
+  const [editingTimeId, setEditingTimeId] = useState<string | null>(null)
+  const [editingTimeValue, setEditingTimeValue] = useState('')
+  const [showExportModal, setShowExportModal] = useState(false)
+  const [exportEntries, setExportEntries] = useState<ImportEntry[]>([])
+  const [isExporting, setIsExporting] = useState(false)
 
-  // this function handles keyUp event in the Notes textarea -> whenever an enter key is hit,
-  // a timestamp is inserted in the Notes
-  const handleNewNoteLine = (e: any) => {
-    const tempNoteValue = noteValue
-    const keycode = e.keyCode ? e.keyCode : e.which
-    if (keycode === parseInt('13')) {
-      setNoteValue(tempNoteValue + currentTime + ' - ')
-      handleNoteAutoSave(tempNoteValue + currentTime + ' - ')
-    }
-  }
-  // for focus event of Notes Textarea -> if the notes is empty, timestamp is inserted
-  const handleTextAreaFocus = (e: any) => {
-    const tempNoteValue = noteValue
-    if (noteValue === '') {
-      setNoteValue(tempNoteValue + currentTime + ' - ')
-      handleNoteAutoSave(tempNoteValue + currentTime + ' - ')
-    }
-    // TODO: what if notes is not empty
-  }
-
-  const handleNoteChange = (e: any) => {
-    let updatedNoteValue = ''
-    handleVideoPause()
-    if (noteValue === '') {
-      // insert current time if all notes is cleared and didn't lose focus
-      updatedNoteValue = currentTime + ' - ' + e.target.value
-    } else if (noteValue.split('').reverse().join('').indexOf('\n') === 0) {
-      // After a new line/enter, if user clears the time and enters note directly
-      // e.nativeEvent.data will have the key entered - adding currentime before that
-      if (e.nativeEvent.data !== null) {
-        updatedNoteValue = noteValue + currentTime + ' - ' + e.nativeEvent.data
-      } else {
-        updatedNoteValue = e.target.value
-      }
-    } else {
-      updatedNoteValue = e.target.value
-    }
-    setNoteValue(updatedNoteValue)
-    debouncedHandleNoteAutoSave(updatedNoteValue)
-  }
-
-  const handleNoteAutoSave = (currentNoteValue: any) => {
+  const handleNoteAutoSave = (current: NoteItem[]) => {
     axios
       .post(`${process.env.REACT_APP_YDX_BACKEND_URL}/api/notes/post-note`, {
-        noteId: noteId,
-        notes: currentNoteValue,
+        noteId,
+        notes: serializeNotes(current),
         adId: audioDescriptionId,
       })
-      .then((res) => {
-        setNoteId(res.data.notes_id) // setting this in the case of inserting new note
-      })
-      .catch((err) => {
-        console.error(err.response.data)
-        toast.error('Error Saving Note! Please Try Again...')
-      })
+      .then(res => setNoteId(res.data.notes_id))
+      .catch(() => toast.error('Error saving note!'))
   }
 
-  const debouncedHandleNoteAutoSave = useMemo(
-    () => debounce(handleNoteAutoSave, 2000),
+  const debouncedSave = useMemo(
+    () => debounce(handleNoteAutoSave, 1500),
     [noteId, audioDescriptionId],
   )
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleNoteHighlight = () => {
-    const noteList = noteValue.split(/\r?\n/)
-    const tempNoteDetails: any[] = []
-    noteList.forEach((note, key) => {
-      if (note.slice(0, 8).match(/\d{2}:\d{2}:\d{2}/)) {
-        const noteTimestamp = {
-          id: key,
-          note: note.slice(11), // assuming user wouldn't mess with the format of the note text
-          time: note.slice(0, 8),
-        }
-        tempNoteDetails.push(noteTimestamp)
-        // console.log(tempNoteDetails)
-        setNoteDetails(tempNoteDetails)
-      }
-    })
+  const updateNotes = (updated: NoteItem[]) => {
+    setNotes(updated)
+    debouncedSave(updated)
+  }
+
+  const handleAddNote = () => {
+    handleVideoPause()
+    const newItem: NoteItem = { id: genId(), timeSeconds: parseCurrentTime(currentTime), text: '' }
+    const updated = [...notes, newItem]
+    setNotes(updated)
+    debouncedSave(updated)
+    // Focus the new text input after render
+    setTimeout(() => {
+      const inputs = document.querySelectorAll<HTMLInputElement>('.note-text-input')
+      inputs[inputs.length - 1]?.focus()
+    }, 50)
+  }
+
+  const handleChangeText = (id: string, text: string) => {
+    updateNotes(notes.map(n => n.id === id ? { ...n, text } : n))
+  }
+
+  const handleDelete = (id: string) => {
+    updateNotes(notes.filter(n => n.id !== id))
+  }
+
+  const handleTimeClick = (note: NoteItem) => {
+    setEditingTimeId(note.id)
+    setEditingTimeValue(formatTime(note.timeSeconds))
+  }
+
+  const handleTimeBlur = (id: string) => {
+    const secs = parseDisplayTime(editingTimeValue)
+    updateNotes(notes.map(n => n.id === id ? { ...n, timeSeconds: secs } : n))
+    setEditingTimeId(null)
+  }
+
+  const handleOpenExport = () => {
+    const entries = notes
+      .filter(n => n.text.trim())
+      .map(n => ({ ...n, playbackType: 'inline' as const, selected: true }))
+    if (entries.length === 0) { toast.info('No notes to export.'); return }
+    setExportEntries(entries)
+    setShowExportModal(true)
+  }
+
+  const handleExportConfirm = async () => {
+    const selected = exportEntries.filter(e => e.selected && e.text.trim())
+    if (selected.length === 0) { toast.info('No entries selected.'); return }
+    setIsExporting(true)
+    let ok = 0, fail = 0
+    for (const entry of selected) {
+      try {
+        const formData = new FormData()
+        formData.append('newACTitle', entry.text.slice(0, 50))
+        formData.append('newACType', 'Visual')
+        formData.append('newACPlaybackType', entry.playbackType)
+        formData.append('newACStartTime', String(entry.timeSeconds))
+        formData.append('newACDescriptionText', entry.text)
+        formData.append('youtubeVideoId', youtubeVideoId)
+        formData.append('userId', userId)
+        formData.append('isRecorded', 'false')
+        formData.append('newACDuration', '0')
+        await axios.post(
+          `${process.env.REACT_APP_YDX_BACKEND_URL}/api/audio-clips/add-new-clip/${audioDescriptionId}`,
+          formData,
+        )
+        ok++
+      } catch { fail++ }
+    }
+    setIsExporting(false)
+    setShowExportModal(false)
+    if (ok > 0) { toast.success(`Exported ${ok} clip${ok > 1 ? 's' : ''}!`); onClipsImported?.() }
+    if (fail > 0) toast.error(`${fail} clip${fail > 1 ? 's' : ''} failed.`)
   }
 
   useEffect(() => {
-    // If there is an notes entry in db
     if (notesData !== undefined) {
-      // inserting notes_text into the note value
-      setNoteValue(notesData.notes_text)
+      setNotes(deserializeNotes(notesData.notes_text))
       setNoteId(notesData.notes_id)
     } else {
-      // else insert empty strings - somehow, useState('') is not working
-      setNoteValue('')
+      setNotes([])
       setNoteId('')
     }
   }, [notesData])
 
   return (
     <div className="notes-bg rounded">
+      {/* Header */}
       <div className="d-flex justify-content-between align-items-center pt-1 px-3 notes-label">
         <h6 className="text-white">Notes:</h6>
+        <button className="btn btn-sm btn-outline-light" onClick={handleOpenExport}>
+          Export to Clips
+        </button>
       </div>
-      <div className="mx-auto my-auto notes-textarea-div align-items-center border rounded">
-        <textarea
-          className="form-control border rounded notes-textarea"
-          rows={9}
-          id="notes"
-          name="notes"
-          placeholder="Start taking your Notes.."
-          onFocus={handleTextAreaFocus}
-          onKeyUp={handleNewNoteLine}
-          onChange={handleNoteChange}
-          value={noteValue}
-        ></textarea>
+
+      {/* Notes list */}
+      <div className="notes-textarea-div px-2 py-1">
+        {notes.length === 0 && (
+          <p className="text-muted small mt-2 px-1">Click "+ Add note" to start.</p>
+        )}
+        {notes.map(note => (
+          <div key={note.id} className="d-flex align-items-center gap-1 mb-1">
+            {/* Time badge / editable input */}
+            {editingTimeId === note.id ? (
+              <input
+                type="text"
+                value={editingTimeValue}
+                onChange={e => setEditingTimeValue(e.target.value)}
+                onBlur={() => handleTimeBlur(note.id)}
+                onKeyDown={e => e.key === 'Enter' && handleTimeBlur(note.id)}
+                autoFocus
+                style={{
+                  width: 60,
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                  padding: '2px 4px',
+                  border: '1px solid #6c9bd1',
+                  borderRadius: 3,
+                  flexShrink: 0,
+                }}
+              />
+            ) : (
+              <span
+                onClick={() => handleTimeClick(note)}
+                title="Click to edit time"
+                style={{
+                  width: 56,
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                  padding: '2px 6px',
+                  background: '#e8f0fe',
+                  color: '#1a4a8a',
+                  borderRadius: 3,
+                  cursor: 'pointer',
+                  flexShrink: 0,
+                  userSelect: 'none',
+                  textAlign: 'center',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {formatTime(note.timeSeconds)}
+              </span>
+            )}
+
+            {/* Text input */}
+            <input
+              type="text"
+              className="note-text-input"
+              value={note.text}
+              onChange={e => handleChangeText(note.id, e.target.value)}
+              placeholder="Note..."
+              style={{
+                flex: 1,
+                fontSize: 13,
+                padding: '2px 6px',
+                border: '1px solid #ccc',
+                borderRadius: 3,
+                minWidth: 0,
+              }}
+            />
+
+            {/* Delete */}
+            <button
+              onClick={() => handleDelete(note.id)}
+              style={{
+                background: 'none', border: 'none', color: '#aaa',
+                cursor: 'pointer', fontSize: 16, lineHeight: 1,
+                padding: '0 2px', flexShrink: 0,
+              }}
+              aria-label="Delete note"
+            >
+              ×
+            </button>
+          </div>
+        ))}
       </div>
+
+      {/* Add button */}
+      <div className="px-3 pb-1 pt-1">
+        <button className="btn btn-sm btn-outline-light w-100" onClick={handleAddNote}>
+          + Add note at current time
+        </button>
+      </div>
+
+      {/* Export modal */}
+      {showExportModal && (
+        <div className="modal d-block" tabIndex={-1} style={{ background: 'rgba(0,0,0,0.5)' }}>
+          <div className="modal-dialog modal-lg">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Export Notes as Clips</h5>
+                <button className="btn-close" onClick={() => setShowExportModal(false)} />
+              </div>
+              <div className="modal-body" style={{ maxHeight: '60vh', overflowY: 'auto' }}>
+                <table className="table table-sm">
+                  <thead>
+                    <tr>
+                      <th style={{ width: 40 }}>
+                        <input
+                          type="checkbox"
+                          checked={exportEntries.every(e => e.selected)}
+                          onChange={ev =>
+                            setExportEntries(exportEntries.map(e => ({ ...e, selected: ev.target.checked })))
+                          }
+                        />
+                      </th>
+                      <th style={{ width: 80 }}>Time</th>
+                      <th>Description</th>
+                      <th style={{ width: 120 }}>Type</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {exportEntries.map((entry, i) => (
+                      <tr key={entry.id} style={{ opacity: entry.selected ? 1 : 0.45 }}>
+                        <td>
+                          <input
+                            type="checkbox"
+                            checked={entry.selected}
+                            onChange={ev =>
+                              setExportEntries(exportEntries.map((e, j) =>
+                                j === i ? { ...e, selected: ev.target.checked } : e
+                              ))
+                            }
+                          />
+                        </td>
+                        <td><code>{formatTime(entry.timeSeconds)}</code></td>
+                        <td>
+                          <input
+                            type="text"
+                            className="form-control form-control-sm"
+                            value={entry.text}
+                            onChange={ev =>
+                              setExportEntries(exportEntries.map((e, j) =>
+                                j === i ? { ...e, text: ev.target.value } : e
+                              ))
+                            }
+                          />
+                        </td>
+                        <td>
+                          <select
+                            className="form-select form-select-sm"
+                            value={entry.playbackType}
+                            onChange={ev =>
+                              setExportEntries(exportEntries.map((e, j) =>
+                                j === i ? { ...e, playbackType: ev.target.value as 'inline' | 'extended' } : e
+                              ))
+                            }
+                          >
+                            <option value="inline">Inline</option>
+                            <option value="extended">Extended</option>
+                          </select>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="modal-footer">
+                <span className="me-auto text-muted" style={{ fontSize: 13 }}>
+                  {exportEntries.filter(e => e.selected).length} of {exportEntries.length} selected
+                </span>
+                <button className="btn btn-secondary" onClick={() => setShowExportModal(false)}>Cancel</button>
+                <button
+                  className="btn btn-primary"
+                  onClick={handleExportConfirm}
+                  disabled={isExporting || exportEntries.filter(e => e.selected).length === 0}
+                >
+                  {isExporting ? 'Exporting...' : 'Export'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/PublishedAudioDescriptions/PublishedAudioDescriptions.tsx
+++ b/src/pages/PublishedAudioDescriptions/PublishedAudioDescriptions.tsx
@@ -141,6 +141,9 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
   const [youTubeVolume, setYouTubeVolume] = useState(
     parseInt(localStorage.getItem('youTubeVolume') || '100'),
   )
+  const [playbackSpeed, setPlaybackSpeed] = useState(
+    parseFloat(localStorage.getItem('playbackSpeed') || '1'),
+  )
 
   const [showModal, setShowModal] = useState(false)
 
@@ -148,6 +151,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
 
   const descriptionVolumeRef = useRef(descriptionVolume)
   const youTubeVolumeRef = useRef(youTubeVolume)
+  const playbackSpeedRef = useRef(playbackSpeed)
 
   const clipStackRef = useRef(clipStack)
   const clipIDRef = useRef(playedAudioClip)
@@ -201,6 +205,17 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
     youTubeVolumeRef.current = youTubeVolume
     localStorage.setItem('youTubeVolume', youTubeVolume.toString())
   }, [youTubeVolume, currentEventRef])
+
+  useEffect(() => {
+    if (currentInlineACRef.current) {
+      currentInlineACRef.current.rate(playbackSpeed)
+    }
+    if (currentExtendedACRef.current) {
+      currentExtendedACRef.current.rate(playbackSpeed)
+    }
+    playbackSpeedRef.current = playbackSpeed
+    localStorage.setItem('playbackSpeed', playbackSpeed.toString())
+  }, [playbackSpeed])
 
   function reset() {
     setSeconds(0)
@@ -619,6 +634,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
                     currentAudio.play()
                     console.log('Extended clip play initiated')
                     currentAudio.volume(descriptionVolumeRef.current / 100)
+                    currentAudio.rate(playbackSpeedRef.current)
                   } else {
                     console.log('Extended clip already playing')
                   }
@@ -633,6 +649,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
                       currentAudio.play()
                       console.log('Extended clip play initiated after load')
                       currentAudio.volume(descriptionVolumeRef.current / 100)
+                      currentAudio.rate(playbackSpeedRef.current)
                     }
                   }, 50)
                 })
@@ -643,6 +660,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
               // Event listeners for play and end
               currentAudio?.once('play', () => {
                 currentAudio.volume(descriptionVolumeRef.current / 100)
+                currentAudio.rate(playbackSpeedRef.current)
               })
 
               currentAudio?.once('end', () => {
@@ -712,6 +730,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
             setTimeout(() => {
               currentAudio.play()
               currentAudio.volume(descriptionVolumeRef.current / 100)
+              currentAudio.rate(playbackSpeedRef.current)
             }, 50)
           } else {
             // Wait for audio to load first
@@ -720,6 +739,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
               setTimeout(() => {
                 currentAudio.play()
                 currentAudio.volume(descriptionVolumeRef.current / 100)
+                currentAudio.rate(playbackSpeedRef.current)
               }, 50)
             })
           }
@@ -737,6 +757,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
             // Event listeners for play and end
             currentAudio?.once('play', () => {
               currentAudio.volume(descriptionVolumeRef.current / 100)
+              currentAudio.rate(playbackSpeedRef.current)
             })
 
             currentAudio?.once('end', () => {
@@ -849,6 +870,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
         }
         if (currInlineAC) {
           // to stop playing -> pause and set time to 0
+          currInlineAC.rate(playbackSpeedRef.current)
           currInlineAC.play()
           currInlineAC.on('end', function () {
             setCurrInlineAC(undefined) // setting back to null, as it is played completely.
@@ -1027,6 +1049,7 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
     if (currExtendedAC) {
       // If an extended clip exists, make it play/pause
       if (isCurrentExtACPaused) {
+        currExtendedAC.rate(playbackSpeedRef.current)
         currExtendedAC.play()
         setCurrentExtACPaused(false)
         setGloballyPaused(false)
@@ -1125,6 +1148,8 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
             setDescriptionVolume={setDescriptionVolume}
             setYouTubeVolume={setYouTubeVolume}
             youTubeVolume={youTubeVolume}
+            playbackSpeed={playbackSpeed}
+            setPlaybackSpeed={setPlaybackSpeed}
           />
           {!isPreviewAudioDescription ? (
             <Notes
@@ -1137,6 +1162,9 @@ const PublishedAudioDescriptions = (): React.ReactElement => {
                   handlePlayPause()
                 }
               }}
+              userId={user || ''}
+              youtubeVideoId={youtubeVideoId || ''}
+              onClipsImported={() => setNeedRefresh(true)}
             />
           ) : (
             <></>

--- a/src/pages/Video/Video.tsx
+++ b/src/pages/Video/Video.tsx
@@ -124,8 +124,12 @@ const Video = () => {
   const [youTubeVolume, setYouTubeVolume] = useState(
     parseInt(localStorage.getItem('youTubeVolume') || '100'),
   )
+  const [playbackSpeed, setPlaybackSpeed] = useState(
+    parseFloat(localStorage.getItem('playbackSpeed') || '1'),
+  )
   const descriptionVolumeRef = useRef(descriptionVolume)
   const youTubeVolumeRef = useRef(youTubeVolume)
+  const playbackSpeedRef = useRef(playbackSpeed)
   const historyTracked = useRef(false)
 
   //
@@ -302,6 +306,17 @@ const Video = () => {
     youTubeVolumeRef.current = youTubeVolume
     localStorage.setItem('youTubeVolume', youTubeVolume.toString())
   }, [youTubeVolume, currentEventRef])
+
+  useEffect(() => {
+    if (currentInlineACRef.current?.playing()) {
+      currentInlineACRef.current?.rate(playbackSpeed)
+    }
+    if (currentExtendedACRef.current?.playing()) {
+      currentExtendedACRef.current?.rate(playbackSpeed)
+    }
+    playbackSpeedRef.current = playbackSpeed
+    localStorage.setItem('playbackSpeed', playbackSpeed.toString())
+  }, [playbackSpeed])
 
   useEffect(() => {
     return () => {
@@ -861,8 +876,9 @@ const Video = () => {
 
     let safetyTimeout: NodeJS.Timeout | null = null
 
-    const startSafetyTimeout = (duration: number) => {
-      const timeoutDuration = (duration + 1) * 1000
+    const startSafetyTimeout = (duration: number, speed: number) => {
+      const effectiveDuration = duration / Math.max(speed, 0.1)
+      const timeoutDuration = (effectiveDuration + 1) * 1000
       console.log(
         `Setting safety timeout: ${timeoutDuration}ms for clip ${clip.clip_id}`,
       )
@@ -883,10 +899,11 @@ const Video = () => {
           console.log(`Extended clip audio starting: ${clip.clip_id}`)
           clip.clip_audio.play()
           clip.clip_audio.volume(descriptionVolumeRef.current / 100)
+          clip.clip_audio.rate(playbackSpeedRef.current)
           const actualDuration =
             clip.clip_audio.duration() || clip.clip_duration || 10
           console.log(`Extended clip actual duration: ${actualDuration}s`)
-          startSafetyTimeout(actualDuration)
+          startSafetyTimeout(actualDuration, playbackSpeedRef.current)
         }
       }, 50)
     } else {
@@ -899,10 +916,11 @@ const Video = () => {
             )
             clip.clip_audio.play()
             clip.clip_audio.volume(descriptionVolumeRef.current / 100)
+            clip.clip_audio.rate(playbackSpeedRef.current)
             const actualDuration =
               clip.clip_audio.duration() || clip.clip_duration || 10
             console.log(`Extended clip actual duration: ${actualDuration}s`)
-            startSafetyTimeout(actualDuration)
+            startSafetyTimeout(actualDuration, playbackSpeedRef.current)
           }
         }, 50)
       })
@@ -963,6 +981,7 @@ const Video = () => {
         if (clip.clip_audio && !clip.clip_audio.playing()) {
           clip.clip_audio.play()
           clip.clip_audio.volume(descriptionVolumeRef.current / 100)
+          clip.clip_audio.rate(playbackSpeedRef.current)
         }
       }, 50)
     } else {
@@ -975,6 +994,7 @@ const Video = () => {
           if (clip.clip_audio && !clip.clip_audio.playing()) {
             clip.clip_audio.play()
             clip.clip_audio.volume(descriptionVolumeRef.current / 100)
+            clip.clip_audio.rate(playbackSpeedRef.current)
           }
         }, 50)
       })
@@ -1076,6 +1096,7 @@ const Video = () => {
           setCurrExtendedAC(undefined)
         }
         if (currInlineAC) {
+          currInlineAC.rate(playbackSpeedRef.current)
           currInlineAC.play()
           currInlineAC.on('end', function () {
             setCurrInlineAC(undefined)
@@ -2004,6 +2025,8 @@ const Video = () => {
               setDescriptionVolume={setDescriptionVolume}
               youTubeVideoVolume={youTubeVolume}
               setYouTubeVideoVolume={setYouTubeVolume}
+              playbackSpeed={playbackSpeed}
+              setPlaybackSpeed={setPlaybackSpeed}
             />
           </div>
           <div className="classic-container video-timeline" aria-hidden="true">
@@ -2032,7 +2055,6 @@ const Video = () => {
               }}
             />
           </div>
-          <ShareBar videoTitle={videoTitle} />
         </section>
         <section
           id="video-info"
@@ -2143,6 +2165,7 @@ const Video = () => {
             </div>
           </div>
         </section>
+        <ShareBar videoTitle={videoTitle} />
       </main>
     </div>
   )

--- a/src/pages/Video/Video.tsx
+++ b/src/pages/Video/Video.tsx
@@ -1986,7 +1986,6 @@ const Video = () => {
       <main role="main" className="video-page-main" title="Video page">
         <section id="video-area" className="video-area">
           {/* <ToastContainer /> */}
-          <ShareBar videoTitle={videoTitle} />
           <div id="video" className="video">
             {showSpinner ? <Spinner /> : null}
             <YouTube
@@ -2033,6 +2032,7 @@ const Video = () => {
               }}
             />
           </div>
+          <ShareBar videoTitle={videoTitle} />
         </section>
         <section
           id="video-info"

--- a/src/pages/Video/Video_v2.tsx
+++ b/src/pages/Video/Video_v2.tsx
@@ -1499,7 +1499,6 @@ const Video = () => {
       <main role="main" className="video-page-main" title="Video page">
         <section id="video-area" className="video-area">
           {/* <ToastContainer /> */}
-          <ShareBar videoTitle={videoTitle} />
           <div id="video" className="video">
             {showSpinner ? <Spinner /> : null}
             <YouTube
@@ -1546,6 +1545,7 @@ const Video = () => {
               }}
             />
           </div>
+          <ShareBar videoTitle={videoTitle} />
         </section>
         <section
           id="video-info"

--- a/src/pages/Video/Video_v2.tsx
+++ b/src/pages/Video/Video_v2.tsx
@@ -76,8 +76,12 @@ const Video = () => {
   const [youTubeVolume, setYouTubeVolume] = useState(
     parseInt(localStorage.getItem('youTubeVolume') || '100'),
   )
+  const [playbackSpeed, setPlaybackSpeed] = useState(
+    parseFloat(localStorage.getItem('playbackSpeed') || '1'),
+  )
   const descriptionVolumeRef = useRef(descriptionVolume)
   const youTubeVolumeRef = useRef(youTubeVolume)
+  const playbackSpeedRef = useRef(playbackSpeed)
 
   //
   // YDX STATE VARIABLES
@@ -117,6 +121,8 @@ const Video = () => {
   const currentEventRef = useRef(currentEvent)
   const currentInlineACRef = useRef(currInlineAC)
   const currentExtendedACRef = useRef(currExtendedAC)
+  const currInlineACSpeedRef = useRef(1)
+  const currExtendedACSpeedRef = useRef(1)
 
   const [previousYTTime, setPreviousYTTime] = useState(0.0)
 
@@ -214,6 +220,17 @@ const Video = () => {
     youTubeVolumeRef.current = youTubeVolume
     localStorage.setItem('youTubeVolume', youTubeVolume.toString())
   }, [youTubeVolume, currentEventRef])
+
+  useEffect(() => {
+    if (currentInlineACRef.current?.playing()) {
+      currentInlineACRef.current?.rate(playbackSpeed)
+    }
+    if (currentExtendedACRef.current?.playing()) {
+      currentExtendedACRef.current?.rate(playbackSpeed)
+    }
+    playbackSpeedRef.current = playbackSpeed
+    localStorage.setItem('playbackSpeed', playbackSpeed.toString())
+  }, [playbackSpeed])
 
   //
   // END OF YDX STATE VARIABLES
@@ -631,6 +648,7 @@ const Video = () => {
                     currentAudio.play()
                     console.log('Extended clip play initiated')
                     currentAudio.volume(descriptionVolumeRef.current / 100)
+                    currentAudio.rate(updatedClip.clip_speed ?? 1)
                   } else {
                     console.log('Extended clip already playing')
                   }
@@ -645,16 +663,19 @@ const Video = () => {
                       currentAudio.play()
                       console.log('Extended clip play initiated after load')
                       currentAudio.volume(descriptionVolumeRef.current / 100)
+                      currentAudio.rate(updatedClip.clip_speed ?? 1)
                     }
                   }, 50)
                 })
               }
 
               setCurrExtendedAC(currentAudio)
+              currExtendedACSpeedRef.current = updatedClip.clip_speed ?? 1
 
               // Event listeners for play and end
               currentAudio?.once('play', () => {
                 currentAudio.volume(descriptionVolumeRef.current / 100)
+                currentAudio.rate(updatedClip.clip_speed ?? 1)
               })
 
               currentAudio?.once('end', () => {
@@ -724,6 +745,7 @@ const Video = () => {
             setTimeout(() => {
               currentAudio.play()
               currentAudio.volume(descriptionVolumeRef.current / 100)
+              currentAudio.rate(updatedClip.clip_speed ?? 1)
             }, 50)
           } else {
             // Wait for audio to load first
@@ -732,11 +754,13 @@ const Video = () => {
               setTimeout(() => {
                 currentAudio.play()
                 currentAudio.volume(descriptionVolumeRef.current / 100)
+                currentAudio.rate(updatedClip.clip_speed ?? 1)
               }, 50)
             })
           }
 
           setCurrInlineAC(currentAudio)
+          currInlineACSpeedRef.current = updatedClip.clip_speed ?? 1
 
           setPlayedAudioClip(updatedClip.clip_id)
           setRecentAudioPlayedTime(currentTimeRef.current)
@@ -749,6 +773,7 @@ const Video = () => {
             // Event listeners for play and end
             currentAudio?.once('play', () => {
               currentAudio.volume(descriptionVolumeRef.current / 100)
+              currentAudio.rate(updatedClip.clip_speed ?? 1)
             })
 
             currentAudio?.once('end', () => {
@@ -851,6 +876,7 @@ const Video = () => {
         }
         if (currInlineAC) {
           // to stop playing -> pause and set time to 0
+          currInlineAC.rate(currInlineACSpeedRef.current)
           currInlineAC.play()
           currInlineAC.on('end', function () {
             setCurrInlineAC(undefined) // setting back to null, as it is played completely.
@@ -1517,6 +1543,8 @@ const Video = () => {
               setDescriptionVolume={setDescriptionVolume}
               youTubeVideoVolume={youTubeVolume}
               setYouTubeVideoVolume={setYouTubeVolume}
+              playbackSpeed={playbackSpeed}
+              setPlaybackSpeed={setPlaybackSpeed}
             />
           </div>
           <div className="classic-container video-timeline" aria-hidden="true">
@@ -1545,7 +1573,6 @@ const Video = () => {
               }}
             />
           </div>
-          <ShareBar videoTitle={videoTitle} />
         </section>
         <section
           id="video-info"
@@ -1671,6 +1698,7 @@ const Video = () => {
             </div>
           </div>
         </section>
+        <ShareBar videoTitle={videoTitle} />
       </main>
     </div>
   )

--- a/src/pages/VideoEmbed/VideoEmbed.tsx
+++ b/src/pages/VideoEmbed/VideoEmbed.tsx
@@ -74,8 +74,12 @@ const VideoEmbed = () => {
   const [youTubeVolume, setYouTubeVolume] = useState(
     parseInt(localStorage.getItem('youTubeVolume') || '100'),
   )
+  const [playbackSpeed, setPlaybackSpeed] = useState(
+    parseFloat(localStorage.getItem('playbackSpeed') || '1'),
+  )
   const descriptionVolumeRef = useRef(descriptionVolume)
   const youTubeVolumeRef = useRef(youTubeVolume)
+  const playbackSpeedRef = useRef(playbackSpeed)
 
   //
   // YDX STATE VARIABLES
@@ -212,6 +216,17 @@ const VideoEmbed = () => {
     youTubeVolumeRef.current = youTubeVolume
     localStorage.setItem('youTubeVolume', youTubeVolume.toString())
   }, [youTubeVolume, currentEventRef])
+
+  useEffect(() => {
+    if (currentInlineACRef.current) {
+      currentInlineACRef.current.rate(playbackSpeed)
+    }
+    if (currentExtendedACRef.current) {
+      currentExtendedACRef.current.rate(playbackSpeed)
+    }
+    playbackSpeedRef.current = playbackSpeed
+    localStorage.setItem('playbackSpeed', playbackSpeed.toString())
+  }, [playbackSpeed])
 
   //
   // END OF YDX STATE VARIABLES
@@ -616,6 +631,7 @@ const VideoEmbed = () => {
                     currentAudio.play()
                     console.log('Extended clip play initiated')
                     currentAudio.volume(descriptionVolumeRef.current / 100)
+                    currentAudio.rate(playbackSpeedRef.current)
                   } else {
                     console.log('Extended clip already playing')
                   }
@@ -630,6 +646,7 @@ const VideoEmbed = () => {
                       currentAudio.play()
                       console.log('Extended clip play initiated after load')
                       currentAudio.volume(descriptionVolumeRef.current / 100)
+                      currentAudio.rate(playbackSpeedRef.current)
                     }
                   }, 50)
                 })
@@ -640,6 +657,7 @@ const VideoEmbed = () => {
               // Event listeners for play and end
               currentAudio?.once('play', () => {
                 currentAudio.volume(descriptionVolumeRef.current / 100)
+                currentAudio.rate(playbackSpeedRef.current)
               })
 
               currentAudio?.once('end', () => {
@@ -709,6 +727,7 @@ const VideoEmbed = () => {
             setTimeout(() => {
               currentAudio.play()
               currentAudio.volume(descriptionVolumeRef.current / 100)
+              currentAudio.rate(playbackSpeedRef.current)
             }, 50)
           } else {
             // Wait for audio to load first
@@ -717,6 +736,7 @@ const VideoEmbed = () => {
               setTimeout(() => {
                 currentAudio.play()
                 currentAudio.volume(descriptionVolumeRef.current / 100)
+                currentAudio.rate(playbackSpeedRef.current)
               }, 50)
             })
           }
@@ -734,6 +754,7 @@ const VideoEmbed = () => {
             // Event listeners for play and end
             currentAudio?.once('play', () => {
               currentAudio.volume(descriptionVolumeRef.current / 100)
+              currentAudio.rate(playbackSpeedRef.current)
             })
 
             currentAudio?.once('end', () => {
@@ -836,6 +857,7 @@ const VideoEmbed = () => {
         }
         if (currInlineAC) {
           // to stop playing -> pause and set time to 0
+          currInlineAC.rate(playbackSpeedRef.current)
           currInlineAC.play()
           currInlineAC.on('end', function () {
             setCurrInlineAC(undefined) // setting back to null, as it is played completely.
@@ -1000,6 +1022,8 @@ const VideoEmbed = () => {
               setDescriptionVolume={setDescriptionVolume}
               youTubeVideoVolume={youTubeVolume}
               setYouTubeVideoVolume={setYouTubeVolume}
+              playbackSpeed={playbackSpeed}
+              setPlaybackSpeed={setPlaybackSpeed}
             />
             <Button
               classNames="mt-5 mb-2"

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -128,8 +128,12 @@ const YDXHome = (): React.ReactElement => {
   const [youTubeVolume, setYouTubeVolume] = useState(
     parseInt(localStorage.getItem('youTubeVolume') || '100'),
   )
+  const [playbackSpeed, setPlaybackSpeed] = useState(
+    parseFloat(localStorage.getItem('playbackSpeed') || '1'),
+  )
   const descriptionVolumeRef = useRef(descriptionVolume)
   const youTubeVolumeRef = useRef(youTubeVolume)
+  const playbackSpeedRef = useRef(playbackSpeed)
 
   const clipStackRef = useRef(clipStack)
   const clipIDRef = useRef(playedAudioClip)
@@ -184,6 +188,17 @@ const YDXHome = (): React.ReactElement => {
     youTubeVolumeRef.current = youTubeVolume
     localStorage.setItem('youTubeVolume', youTubeVolume.toString())
   }, [youTubeVolume, currentEventRef])
+
+  useEffect(() => {
+    if (currentInlineACRef.current) {
+      currentInlineACRef.current.rate(playbackSpeed)
+    }
+    if (currentExtendedACRef.current) {
+      currentExtendedACRef.current.rate(playbackSpeed)
+    }
+    playbackSpeedRef.current = playbackSpeed
+    localStorage.setItem('playbackSpeed', playbackSpeed.toString())
+  }, [playbackSpeed])
 
   useEffect(() => {
     if (unitLength > 0 && videoId) {
@@ -673,6 +688,7 @@ const YDXHome = (): React.ReactElement => {
                     currentAudio.play()
                     console.log('Extended clip play initiated')
                     currentAudio.volume(descriptionVolumeRef.current / 100)
+                    currentAudio.rate(playbackSpeedRef.current)
                   } else {
                     console.log('Extended clip already playing')
                   }
@@ -687,6 +703,7 @@ const YDXHome = (): React.ReactElement => {
                       currentAudio.play()
                       console.log('Extended clip play initiated after load')
                       currentAudio.volume(descriptionVolumeRef.current / 100)
+                      currentAudio.rate(playbackSpeedRef.current)
                     }
                   }, 50)
                 })
@@ -697,6 +714,7 @@ const YDXHome = (): React.ReactElement => {
               // Event listeners for play and end
               currentAudio?.once('play', () => {
                 currentAudio.volume(descriptionVolumeRef.current / 100)
+                currentAudio.rate(playbackSpeedRef.current)
               })
 
               currentAudio?.once('end', () => {
@@ -775,6 +793,7 @@ const YDXHome = (): React.ReactElement => {
             setTimeout(() => {
               currentAudio.play()
               currentAudio.volume(descriptionVolumeRef.current / 100)
+              currentAudio.rate(playbackSpeedRef.current)
             }, 50)
           } else {
             // Wait for audio to load first
@@ -783,6 +802,7 @@ const YDXHome = (): React.ReactElement => {
               setTimeout(() => {
                 currentAudio.play()
                 currentAudio.volume(descriptionVolumeRef.current / 100)
+                currentAudio.rate(playbackSpeedRef.current)
               }, 50)
             })
           }
@@ -802,6 +822,7 @@ const YDXHome = (): React.ReactElement => {
             // Event listeners for play and end
             currentAudio?.once('play', () => {
               currentAudio.volume(descriptionVolumeRef.current / 100)
+              currentAudio.rate(playbackSpeedRef.current)
             })
 
             currentAudio?.once('end', () => {
@@ -917,6 +938,7 @@ const YDXHome = (): React.ReactElement => {
         }
         if (currInlineAC) {
           // to stop playing -> pause and set time to 0
+          currInlineAC.rate(playbackSpeedRef.current)
           currInlineAC.play()
           currInlineAC.on('end', function () {
             setCurrInlineAC(undefined) // setting back to null, as it is played completely.
@@ -1097,6 +1119,7 @@ const YDXHome = (): React.ReactElement => {
     if (currExtendedAC) {
       // If an extended clip exists, make it play/pause
       if (isCurrentExtACPaused) {
+        currExtendedAC.rate(playbackSpeedRef.current)
         currExtendedAC.play()
         setCurrentExtACPaused(false)
         setGloballyPaused(false)
@@ -1206,7 +1229,7 @@ const YDXHome = (): React.ReactElement => {
     clipDescriptionType: string | undefined,
   ) => {
     try {
-      await axios.put(
+      const response = await axios.put(
         `${process.env.REACT_APP_YDX_BACKEND_URL}/api/audio-clips/update-clip-description/${clipId}`,
         {
           userId: user,
@@ -1218,6 +1241,7 @@ const YDXHome = (): React.ReactElement => {
       )
 
       setUpdateData(!updateData)
+      return response.data
     } catch (err: any) {
       if (err.response) {
         toast.error(err.response.data.message) // show toast message
@@ -1225,6 +1249,7 @@ const YDXHome = (): React.ReactElement => {
         console.error(err)
         toast.error('An error occurred. Please try again!!')
       }
+      throw err
     }
   }
 
@@ -1274,6 +1299,8 @@ const YDXHome = (): React.ReactElement => {
             setDescriptionVolume={setDescriptionVolume}
             setYouTubeVolume={setYouTubeVolume}
             youTubeVolume={youTubeVolume}
+            playbackSpeed={playbackSpeed}
+            setPlaybackSpeed={setPlaybackSpeed}
           />
           <Notes
             currentTime={convertSecondsToCardFormat(currentTime)}
@@ -1285,6 +1312,9 @@ const YDXHome = (): React.ReactElement => {
                 handlePlayPause()
               }
             }}
+            userId={user || ''}
+            youtubeVideoId={youtubeVideoId || ''}
+            onClipsImported={() => setNeedRefresh(true)}
           />
         </div>
         <hr className="m-2 ydx-hr" />

--- a/src/shared/components/VideoPlayerControls/VideoPlayerControls.tsx
+++ b/src/shared/components/VideoPlayerControls/VideoPlayerControls.tsx
@@ -3,11 +3,15 @@ import { ChangeEvent, useMemo, useState } from 'react'
 import Form from 'react-bootstrap/Form'
 import './videoPlayerControls.scss'
 
+const SPEED_OPTIONS = [1, 1.2, 1.5, 2]
+
 interface Props {
   descriptionVolume: number
   setDescriptionVolume: (value: number) => void
   youTubeVideoVolume: number
   setYouTubeVideoVolume: (value: number) => void
+  playbackSpeed?: number
+  setPlaybackSpeed?: (value: number) => void
 }
 
 const VideoPlayerControls = ({
@@ -15,6 +19,8 @@ const VideoPlayerControls = ({
   setDescriptionVolume,
   youTubeVideoVolume,
   setYouTubeVideoVolume,
+  playbackSpeed = 1,
+  setPlaybackSpeed = () => undefined,
 }: Props) => {
   const [descriptionValue, setDescriptionValue] =
     useState<number>(descriptionVolume)
@@ -115,6 +121,25 @@ const VideoPlayerControls = ({
           </div>
           <div className="col-sm-6 col-md-6 col-lg-6">
             <Form.Label className="form-range-label">Video Volume</Form.Label>
+          </div>
+          <div className="col-12">
+            <h6 className="classic-h6">Description Speed</h6>
+          </div>
+          <div className="col-12">
+            <div className="speed-buttons" role="group" aria-label="Audio description playback speed">
+              {SPEED_OPTIONS.map(speed => (
+                <button
+                  key={speed}
+                  type="button"
+                  className={`speed-btn${playbackSpeed === speed ? ' active' : ''}`}
+                  onClick={() => setPlaybackSpeed(speed)}
+                  aria-pressed={playbackSpeed === speed}
+                  aria-label={`Set description speed to ${speed}x`}
+                >
+                  {speed}x
+                </button>
+              ))}
+            </div>
           </div>
           {/* <FullscreenButton playFullscreen={props.playFullscreen} />
       <VideoTimer {...props} /> */}

--- a/src/shared/components/VideoPlayerControls/VideoPlayerControls.tsx
+++ b/src/shared/components/VideoPlayerControls/VideoPlayerControls.tsx
@@ -126,12 +126,18 @@ const VideoPlayerControls = ({
             <h6 className="classic-h6">Description Speed</h6>
           </div>
           <div className="col-12">
-            <div className="speed-buttons" role="group" aria-label="Audio description playback speed">
-              {SPEED_OPTIONS.map(speed => (
+            <div
+              className="speed-buttons"
+              role="group"
+              aria-label="Audio description playback speed"
+            >
+              {SPEED_OPTIONS.map((speed) => (
                 <button
                   key={speed}
                   type="button"
-                  className={`speed-btn${playbackSpeed === speed ? ' active' : ''}`}
+                  className={`speed-btn${
+                    playbackSpeed === speed ? ' active' : ''
+                  }`}
                   onClick={() => setPlaybackSpeed(speed)}
                   aria-pressed={playbackSpeed === speed}
                   aria-label={`Set description speed to ${speed}x`}

--- a/src/shared/components/VideoPlayerControls/videoPlayerControls.scss
+++ b/src/shared/components/VideoPlayerControls/videoPlayerControls.scss
@@ -9,3 +9,29 @@
 .question-font {
   font-size: 16px;
 }
+
+.speed-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+
+  .speed-btn {
+    padding: 3px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 13px;
+
+    &.active {
+      background: var(--primary-color, #0d6efd);
+      color: #fff;
+      border-color: var(--primary-color, #0d6efd);
+    }
+
+    &:hover:not(.active) {
+      background: #f0f0f0;
+    }
+  }
+}

--- a/src/shared/strings.ts
+++ b/src/shared/strings.ts
@@ -5,6 +5,8 @@ const strings = {
     HOME: 'INÍCIO',
     Close: 'Fechar',
     Search: 'Busca',
+    'Search by title, tags, describer name, or YouTube ID':
+      'Busque por titulo, tags, nome do descritor ou ID do YouTube',
     Credits: 'Créditos',
     'Contact Us': 'Contato',
     Support: 'Suporte',
@@ -163,6 +165,8 @@ const strings = {
     HOME: 'HOME',
     Close: 'Close',
     Search: 'Search',
+    'Search by title, tags, describer name, or YouTube ID':
+      'Search by title, tags, describer name, or YouTube ID',
     Credits: 'Credits',
     'Contact Us': 'Contact Us',
     Support: 'Support',

--- a/src/shared/utils/convertClipObject.ts
+++ b/src/shared/utils/convertClipObject.ts
@@ -11,6 +11,7 @@ export interface Clip {
   clip_start_time: number
   clip_end_time: number
   clip_sequence_number: number
+  clip_speed: number
   createdAt: string
   description_text?: string
   description_type?: string
@@ -34,6 +35,7 @@ const convertClipObject = (clip: any) => {
     description_type: clip.description_type,
     is_recorded: clip.is_recorded,
     playback_type: clip.playback_type,
+    clip_speed: clip.clip_speed ?? 1,
     updatedAt: clip.updatedAt,
   }
   return newClip
@@ -51,6 +53,7 @@ export const convertClassicClipObject = (clip: any) => {
     clip_start_time: clip.start_time,
     clip_end_time: clip.end_time,
     clip_sequence_number: clip.clip_sequence_number ?? 0,
+    clip_speed: clip.speed ?? 1,
     description_text: clip.description_text,
     description_type: clip.description_type,
     is_recorded: clip.is_recorded,

--- a/src/shared/utils/getBlobAudioDuration.ts
+++ b/src/shared/utils/getBlobAudioDuration.ts
@@ -1,0 +1,34 @@
+const getBlobAudioDuration = (blobUrl: string): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const audio = new Audio(blobUrl)
+
+    const cleanup = () => {
+      audio.onloadedmetadata = null
+      audio.ontimeupdate = null
+      audio.onerror = null
+    }
+
+    audio.onerror = () => {
+      cleanup()
+      reject(new Error('Unable to read recorded audio duration'))
+    }
+
+    audio.onloadedmetadata = () => {
+      if (Number.isFinite(audio.duration) && audio.duration > 0) {
+        const duration = Math.round(audio.duration * 1000) / 1000
+        cleanup()
+        resolve(duration)
+        return
+      }
+
+      audio.currentTime = 1e101
+      audio.ontimeupdate = () => {
+        const duration = Math.round(audio.duration * 1000) / 1000
+        audio.currentTime = 0
+        cleanup()
+        resolve(duration)
+      }
+    }
+  })
+
+export default getBlobAudioDuration


### PR DESCRIPTION
## Summary
- **Speed control**: Moved per-clip playback speed buttons (0.75x–2x) from the expanded EditClip area to the clip card header, inline with Inline/Extended toggles. Includes a "Speed:" label and divider for clarity. Speed is persisted to the database.
- **Notes → Export to Clips**: Notes redesigned as a structured list with editable MM:SS timestamps. New "Export to Clips" button opens a modal to bulk-create inline/extended TTS clips from notes.
- **Compact EditClip UI**: Reduced font sizes and padding in the description editing area for a less bulky appearance.
- **Bug fix**: Voice recording now stores the actual audio duration (fixes invisible timeline bar and 0:00 duration display).
- **Bug fix**: TTS audio is cleared before script regeneration so stale audio can't be played.

## Related backend PR
youdescribe-sfsu/YouDescribeX-api — `feature/liangyue-speed-notes` (adds `clip_speed` field + update endpoint)

## Test plan
- [ ] Create a voice recording clip — check Duration shows actual length and yellow bar appears on timeline
- [ ] Edit a TTS clip description, save — clicking Play immediately should be silent; after refresh it plays new audio
- [ ] Change speed on a clip card — verify speed buttons highlight and audio plays at correct rate
- [ ] Add notes with timestamps, click "Export to Clips" — verify clips are created with correct text and start time
- [ ] Confirm Notes content is preserved after export

🤖 Generated with [Claude Code](https://claude.com/claude-code)