### PR TITLE
fix(home): invalidate localStorage cache on publish/unpublish

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -163,6 +163,8 @@ const videoCache = {
   },
 }
 
+export const invalidateHomeVideoCache = () => videoCache.invalidateCache()
+
 const Home = () => {
   const [currentPage, setCurrentPage] = useState(1)
   const [rawVideoData, setRawVideoData] = useState<VideoData[]>([])

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -37,6 +37,7 @@ import { TUTORIAL_TARGETS } from '../features/Tutorial/tutorialSelectors'
 import { useTutorialEditorAdapter } from '../features/Tutorial/useTutorialEditorAdapter'
 import type { TutorialMode } from '../features/Tutorial/tutorialStepRegistry'
 import { useAudioDescriptionEngine } from '../shared/hooks/useAudioDescriptionEngine' // <-- Add import
+import { invalidateHomeVideoCache } from '@/pages/Home/Home'
 
 type DialogTimestamp = {
   dialog_seq_no: number
@@ -1341,6 +1342,7 @@ const YDXHome = ({
       )
       setNeedRefresh(true)
       toast.success('Audio description published successfully!')
+      invalidateHomeVideoCache()
       window.location.href = `${window.location.origin}/video/${youtubeVideoId}?ad=${audioDescriptionId}`
     } catch (error) {
       console.error(error)
@@ -1363,6 +1365,7 @@ const YDXHome = ({
       setIsPublished(false)
       setNeedRefresh(true)
       toast.success('Audio description unpublished successfully!')
+      invalidateHomeVideoCache()
     } catch (error) {
       console.error('Error unpublishing audio description:', error)
       toast.error('Error unpublishing audio description!')


### PR DESCRIPTION
## Summary

The home page's **Recent Descriptions** section caches video data in `localStorage` for 5 minutes using:

- `ydx-home-page-N-v2`
- `ydx-home-videos-data`

However, this client-side cache was not invalidated when an audio description's publish state changed. As a result, a newly published video might not appear immediately, or a newly unpublished video might continue to show until the cache TTL expired.

This PR clears the home page client-side cache after both publish and unpublish actions, so the home page reflects the updated state on the next visit.

## Key Changes

- `src/pages/Home/Home.tsx`
  - Export `videoCache.invalidateCache` as `invalidateHomeVideoCache`.
  - This allows other pages to clear the home page cache without duplicating `localStorage` key names.

- `src/pages/YDXHome.tsx`
  - Call `invalidateHomeVideoCache()` after a successful publish.
  - The cache is cleared before `window.location.href` redirects, so the next page load starts with fresh data.
  - Call `invalidateHomeVideoCache()` after a successful unpublish.

Only 5 lines were added, with no other behavior changed.

Server-side invalidation in `audioDescriptions.service.ts` was already working correctly. The missing piece was client-side cache invalidation.

## Test Plan

1. Publish an audio description from the editor.
   - Navigate to `/`.
   - Confirm the video appears immediately.

2. Unpublish that audio description.
   - Navigate to `/`.
   - Confirm the video disappears immediately when it is the only published audio description on that video.

3. Verify cache invalidation in DevTools.
   - Open **Application → Local Storage**.
   - Confirm the following keys are cleared after each publish/unpublish toggle:
     - `ydx-home-page-1-v2`
     - `ydx-home-videos-data`