### PR TITLE
fix(home): invalidate localStorage cache on publish/unpublish

### DIFF
--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -37,6 +37,7 @@ import { TUTORIAL_TARGETS } from '../features/Tutorial/tutorialSelectors'
 import { useTutorialEditorAdapter } from '../features/Tutorial/useTutorialEditorAdapter'
 import type { TutorialMode } from '../features/Tutorial/tutorialStepRegistry'
 import { useAudioDescriptionEngine } from '../shared/hooks/useAudioDescriptionEngine' // <-- Add import
+import { invalidateHomeVideoCache } from '../shared/utils/homeVideoCache'
 
 type DialogTimestamp = {
   dialog_seq_no: number
@@ -1341,6 +1342,7 @@ const YDXHome = ({
       )
       setNeedRefresh(true)
       toast.success('Audio description published successfully!')
+      invalidateHomeVideoCache()
       window.location.href = `${window.location.origin}/video/${youtubeVideoId}?ad=${audioDescriptionId}`
     } catch (error) {
       console.error(error)
@@ -1363,6 +1365,7 @@ const YDXHome = ({
       setIsPublished(false)
       setNeedRefresh(true)
       toast.success('Audio description unpublished successfully!')
+      invalidateHomeVideoCache()
     } catch (error) {
       console.error('Error unpublishing audio description:', error)
       toast.error('Error unpublishing audio description!')

--- a/src/shared/utils/homeVideoCache.ts
+++ b/src/shared/utils/homeVideoCache.ts
@@ -1,0 +1,17 @@
+// Constants and helpers for the home page's "Recent Descriptions" localStorage cache.
+// Keep these key names and the CACHE_VERSION in sync with src/pages/Home/Home.tsx.
+
+const CACHE_VERSION = 'v2'
+const MAX_PAGES_TO_CACHE = 3
+
+export const invalidateHomeVideoCache = (): void => {
+  try {
+    for (let i = 1; i <= MAX_PAGES_TO_CACHE; i++) {
+      localStorage.removeItem(`ydx-home-page-${i}-${CACHE_VERSION}`)
+    }
+    localStorage.removeItem('ydx-home-videos-data')
+    localStorage.removeItem('ydx-home-max-page')
+  } catch (error) {
+    console.error('Error invalidating home video cache:', error)
+  }
+}


### PR DESCRIPTION
## Summary

The home page's **Recent Descriptions** section caches video data in `localStorage` for 5 minutes using:

- `ydx-home-page-N-v2`
- `ydx-home-videos-data`

However, this client-side cache was not invalidated when an audio description's publish state changed. As a result, a newly published video might not appear immediately, or a newly unpublished video might continue to show until the cache TTL expired.

This PR clears the home page client-side cache after both publish and unpublish actions, so the home page reflects the updated state on the next visit.

## Key Changes

- **New file:** `src/shared/utils/homeVideoCache.ts` — self-contained helper exporting `invalidateHomeVideoCache()` that clears all home-page `localStorage` keys (`ydx-home-page-N-v2`, `ydx-home-videos-data`, `ydx-home-max-page`). Has a comment noting the cache keys must stay in sync with `Home.tsx`.

- `src/pages/YDXHome.tsx`
  - Import `invalidateHomeVideoCache` from the new util.
  - Call `invalidateHomeVideoCache()` after a successful publish (before `window.location.href` redirects, so the next page load starts with fresh data).
  - Call `invalidateHomeVideoCache()` after a successful unpublish.

`src/pages/Home/Home.tsx` is **not touched** — the existing `videoCache.invalidateCache` logic remains in place; the new util mirrors the same key-clearing behavior so it can be called from outside `Home.tsx` without dragging the page's `@/`-aliased imports into other module graphs.

Server-side invalidation in `audioDescriptions.service.ts` was already working correctly. The missing piece was client-side cache invalidation.

## Test Plan

1. Publish an audio description from the editor.
   - Navigate to `/`.
   - Confirm the video appears immediately.

2. Unpublish that audio description.
   - Navigate to `/`.
   - Confirm the video disappears immediately when it is the only published audio description on that video.

3. Verify cache invalidation in DevTools.
   - Open **Application → Local Storage**.
   - Confirm the following keys are cleared after each publish/unpublish toggle:
     - `ydx-home-page-1-v2`
     - `ydx-home-videos-data`

## Notes on `npm test`

`CI=true npm test` on this branch: **5 suites load, 22/24 cases pass**. The 2 failing cases (`YDXHome.test.tsx › pauses on playhead grab ...` and `... renders the editor playhead with the expanded hit area class`) are **pre-existing failures already present on `origin/dev`** — verified by running the same suite on a clean `c0e7ed6` checkout, which produces the identical 2 failures. They are unrelated to this change.

`npm run build` passes (CI green).
