### PR TITLE
fix: add auth three-state and 401 interceptor to fix silent logout bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer } from 'react-toastify' // for toast messages
+import { ToastContainer, toast } from 'react-toastify' // for toast messages
+import axios from 'axios'
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'
 import Home from './pages/Home/Home'
@@ -80,14 +81,20 @@ const resetCookie = () => {
   document.cookie = `userName=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
   document.cookie = `userPicture=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
 }
+
+// xiao: 0713
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
+
 interface UserStore {
   isSignedIn: boolean
+  authStatus: AuthStatus
   userId: string
   userToken: string
   userName: string
   userPicture: string
   userAdmin: number
   setSignedIn: (isSignedIn: boolean) => void
+  setAuthStatus: (authStatus: AuthStatus) => void
   setUserId: (userId: string) => void
   setUserToken: (userToken: string) => void
   setUserName: (userName: string) => void
@@ -99,12 +106,14 @@ interface UserStore {
 export const userDataStore = create<UserStore>()(
   devtools((set) => ({
     isSignedIn: false,
+    authStatus: 'loading',
     userId: '',
     userToken: '',
     userName: '',
     userPicture: '',
     userAdmin: 0,
     setSignedIn: (isSignedIn: boolean) => set({ isSignedIn }),
+    setAuthStatus: (authStatus: AuthStatus) => set({ authStatus }),
     setUserId: (userId: string) => set({ userId }),
     setUserToken: (userToken: string) => set({ userToken }),
     setUserName: (userName: string) => set({ userName }),
@@ -113,6 +122,7 @@ export const userDataStore = create<UserStore>()(
     clearUserData: () => {
       set({
         isSignedIn: false,
+        authStatus: 'unauthenticated',
         userId: '',
         userToken: '',
         userName: '',
@@ -123,6 +133,18 @@ export const userDataStore = create<UserStore>()(
       resetCookie()
     },
   })),
+)
+
+// Detect session expiration at runtime, if any Axios request returns 401, immediately treat the user as logged out
+axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error?.response?.status === 401) {
+      userDataStore.getState().clearUserData()
+      toast.error('Your session has expired. Please sign in again.')
+    }
+    return Promise.reject(error)
+  },
 )
 
 const App = () => {
@@ -141,6 +163,7 @@ const App = () => {
 
   const {
     setSignedIn,
+    setAuthStatus,
     setUserId,
     setUserToken,
     setUserName,
@@ -149,6 +172,7 @@ const App = () => {
   } = userDataStore((state) => {
     return {
       setSignedIn: state.setSignedIn,
+      setAuthStatus: state.setAuthStatus,
       setUserId: state.setUserId,
       setUserToken: state.setUserToken,
       setUserName: state.setUserName,
@@ -226,13 +250,21 @@ const App = () => {
       const response = await fetch(url, {
         credentials: 'include',
       })
+      if (!response.ok) {
+        clearUserData()
+        return
+      }
       const data = await response.json()
-
+      if (!data?.result) {
+        clearUserData()
+        return
+      }
       setUserData(data.result)
       handleRedirect()
     } catch (error) {
       //}
       console.error('Login error:', error)
+      clearUserData()
     }
   }
 
@@ -242,6 +274,7 @@ const App = () => {
     setUserId(result._id)
     setUserToken(result.token)
     setUserPicture(result.picture)
+    setAuthStatus('authenticated')
     setUserAdmin(result.admin)
     setSignedIn(true)
     setCookie(result._id, result.token, result.name, result.picture)
@@ -292,11 +325,11 @@ const App = () => {
     name: string,
     picture: string,
   ) => {
-    const now = new Date()
-    let time = now.getTime()
-    time += 20 * 1000
-    now.setTime(time)
-    const exp = now.toUTCString()
+    // const now = new Date()
+    // let time = now.getTime()
+    // time += 20 * 1000
+    // now.setTime(time)
+    // const exp = now.toUTCString()
     document.cookie = `userId=${id};path=/`
     document.cookie = `userToken=${token};path=/`
     document.cookie = `userName=${name};path=/`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,8 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer, toast } from 'react-toastify' // for toast messages
-import axios from 'axios'
+import { ToastContainer, toast } from 'react-toastify'  // xiao: toast used for session expiration notification
+import axios from 'axios' // xiao: axios imported for 401 response interceptor
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'
 import Home from './pages/Home/Home'
@@ -82,7 +82,7 @@ const resetCookie = () => {
   document.cookie = `userPicture=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
 }
 
-// xiao: 0713
+// xiao: three-state auth — 'loading' = haven't checked backend, 'authenticated' = confirmed, 'unauthenticated' = denied
 export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
 
 interface UserStore {
@@ -122,6 +122,7 @@ export const userDataStore = create<UserStore>()(
     clearUserData: () => {
       set({
         isSignedIn: false,
+        // xiao: explicitly mark as unauthenticated so UI knows backend denied login
         authStatus: 'unauthenticated',
         userId: '',
         userToken: '',
@@ -135,7 +136,7 @@ export const userDataStore = create<UserStore>()(
   })),
 )
 
-// Detect session expiration at runtime, if any Axios request returns 401, immediately treat the user as logged out
+// xiao: intercept all axios responses — any 401 means session expired, clear login state immediately
 axios.interceptors.response.use(
   (response) => response,
   (error) => {
@@ -250,11 +251,13 @@ const App = () => {
       const response = await fetch(url, {
         credentials: 'include',
       })
+      // xiao: backend returns 500 when not logged in, fetch doesn't throw on 500 — must check response.ok explicitly
       if (!response.ok) {
         clearUserData()
         return
       }
       const data = await response.json()
+      // xiao: safety check — 200 but no result means unexpected response, treat as not logged in
       if (!data?.result) {
         clearUserData()
         return
@@ -262,8 +265,8 @@ const App = () => {
       setUserData(data.result)
       handleRedirect()
     } catch (error) {
-      //}
       console.error('Login error:', error)
+      // xiao: network error — clear fake login state instead of silently ignoring
       clearUserData()
     }
   }
@@ -274,6 +277,7 @@ const App = () => {
     setUserId(result._id)
     setUserToken(result.token)
     setUserPicture(result.picture)
+    // xiao: backend confirmed login — set authoritative auth state
     setAuthStatus('authenticated')
     setUserAdmin(result.admin)
     setSignedIn(true)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer, toast } from 'react-toastify'  // xiao: toast used for session expiration notification
+import { ToastContainer, toast } from 'react-toastify' // xiao: toast used for session expiration notification
 import axios from 'axios' // xiao: axios imported for 401 response interceptor
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'

--- a/src/shared/components/Navbar/Navbar.tsx
+++ b/src/shared/components/Navbar/Navbar.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   const location = useLocation()
-  const authStatus = userDataStore((s) => s.authStatus)
+  const authStatus = userDataStore((s) => s.authStatus) // xiao: reactive subscription — re-renders when auth state changes
 
   const navMenuOpen = () => {
     const mySidenav = document.getElementById('mySidenav')
@@ -43,6 +43,7 @@ const Navbar = ({ newGoogleAuth, signOut }: Props) => {
     }
   }
 
+  // xiao: three-state rendering — nothing while checking, avatar when confirmed, sign-in button when denied
   const signInComponent = () => {
     if (authStatus === 'loading') {
       return null

--- a/src/shared/components/Navbar/Navbar.tsx
+++ b/src/shared/components/Navbar/Navbar.tsx
@@ -13,6 +13,7 @@ interface Props {
 
 const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   const location = useLocation()
+  const authStatus = userDataStore((s) => s.authStatus)
 
   const navMenuOpen = () => {
     const mySidenav = document.getElementById('mySidenav')
@@ -43,11 +44,13 @@ const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   }
 
   const signInComponent = () => {
-    if (userDataStore.getState().isSignedIn) {
-      return <UserAvatar userMenuToggle={userMenuToggle} signOut={signOut} />
-    } else {
-      return <SignInButton newGoogleAuth={newGoogleAuth} />
+    if (authStatus === 'loading') {
+      return null
     }
+    if (authStatus === 'authenticated') {
+      return <UserAvatar userMenuToggle={userMenuToggle} signOut={signOut} />
+    }
+    return <SignInButton newGoogleAuth={newGoogleAuth} />
   }
   const myHistoryUrl = `/videos/history`
 


### PR DESCRIPTION
## Description
Fix silent logout bug where frontend fails to detect expired backend session.

- App.tsx: Add authStatus three-state (loading/authenticated/unauthenticated), fix newGoogleLogin silently swallowing backend error responses, add axios 401 interceptor
- Navbar.tsx: Switch to reactive authStatus subscription with three-state rendering

## Motivation and Context
When session expired, frontend stayed in fake logged-in state. Root cause: newGoogleLogin did not handle backend error responses — catch block silently swallowed errors, leaving stale cookie login state intact.

## How has this been tested?
- Normal login/logout: works correctly
- Fake cookie + refresh: correctly shows sign-in button
- Delete session cookie + action (no refresh): interceptor triggers, immediately shows sign-out state