### PR TITLE
Profile: Reduce Option A to two checkboxes, modified text of option B.

### DIFF
--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -11,11 +11,7 @@ interface ProfileParams {
 }
 
 const Profile = () => {
-  const [optInChoices, setOptInChoices] = useState<boolean[]>([
-    false,
-    false,
-    false,
-  ])
+  const [optInChoices, setOptInChoices] = useState<boolean[]>([false, false])
   const [optIn, setOptIn] = useState<boolean>(false)
   const [reviewStatus, setReviewStatus] = useState<string>('')
 
@@ -33,12 +29,14 @@ const Profile = () => {
       const url = `${apiUrl}/users/${userId}`
       const response = await ourFetch(url)
       const user = response.result
-      const choices = [false, false, false]
-      user.opt_in.forEach((index: number) => {
-        choices[index] = true
-      })
+      // Each checkbox is persisted in its own field. choices[0] = wishlist
+      // published, choices[1] = automated AI feedback.
+      const choices = [
+        user.opt_in_wishlist_published === true,
+        user.opt_in_ai_feedback === true,
+      ]
       setOptInChoices(choices)
-      setOptIn(user.opt_in.length > 0)
+      setOptIn(user.opt_in === true)
       setReviewStatus(user.policy_review)
     } catch (error) {
       console.error('Failed to load user data:', error)
@@ -47,14 +45,8 @@ const Profile = () => {
 
   const handleCheckBoxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const index = parseInt(event.target.id)
-    let choices = [...optInChoices]
-    if (index === 3) {
-      choices = event.target.checked
-        ? [true, true, true]
-        : [false, false, false]
-    } else {
-      choices[index] = event.target.checked
-    }
+    const choices = [...optInChoices]
+    choices[index] = event.target.checked
     setOptInChoices(choices)
     setOptIn(true)
     setReviewStatus('reviewed')
@@ -65,7 +57,7 @@ const Profile = () => {
   ) => {
     const value = event.target.value
     if (value === 'off') {
-      setOptInChoices([false, false, false])
+      setOptInChoices([false, false])
       setOptIn(false)
     } else {
       setOptIn(true)
@@ -77,12 +69,7 @@ const Profile = () => {
     if (reviewStatus !== 'reviewed') {
       alert('Sorry, you have not made any choice yet.')
       return
-    } else if (
-      optIn &&
-      !optInChoices[0] &&
-      !optInChoices[1] &&
-      !optInChoices[2]
-    ) {
+    } else if (optIn && !optInChoices[0] && !optInChoices[1]) {
       alert('Sorry, you have not selected any opt-in checkbox.')
       return
     }
@@ -131,51 +118,48 @@ const Profile = () => {
           value="on"
           onChange={handleRadioButtonChange}
         />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[0]}
-          name="optinchoices"
-          label={translate(
-            'My wishlist selection has been described and published',
-          )}
-          id="0"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[1]}
-          name="optinchoices"
-          label={translate('My audio description has been viewed')}
-          id="1"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[2]}
-          name="optinchoices"
-          label={translate(
-            'I wish to receive automated feedback on my published audio descriptions',
-          )}
-          id="2"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices.every((choice) => choice)}
-          label={translate('I would like to receive all notifications')}
-          id="3"
-          onChange={handleCheckBoxChange}
-        />
+        <p
+          id="optin-required-hint"
+          className="optin-helper-text"
+          style={{ marginLeft: '1.5em', fontSize: '0.85rem' }}
+        >
+          {translate('(Please select at least one option below)')}
+        </p>
+        <div
+          role="group"
+          aria-label={translate('A. Yes I want to be notified by email when:')}
+          aria-required={optIn}
+          aria-describedby={optIn ? 'optin-required-hint' : undefined}
+        >
+          <Form.Check
+            style={{ marginLeft: 20 }}
+            type="checkbox"
+            checked={optInChoices[0]}
+            name="optinchoices"
+            label={translate(
+              'My wishlist selection has been described and published',
+            )}
+            id="0"
+            onChange={handleCheckBoxChange}
+          />
+          <Form.Check
+            style={{ marginLeft: 20 }}
+            type="checkbox"
+            checked={optInChoices[1]}
+            name="optinchoices"
+            label={translate(
+              'I wish to receive automated feedback on my published audio descriptions',
+            )}
+            id="1"
+            onChange={handleCheckBoxChange}
+          />
+        </div>
         <br />
         <Form.Check
           type="radio"
           checked={reviewStatus === 'reviewed' && !optIn}
           label={translate(
-            'B. I do not want any automated notifications from YouDescribe.',
+            "B. I don't want to receive notifications for any of the options above.",
           )}
           name="optin"
           value="off"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Reduce Option A to two checkboxes (wishlist published, AI feedback),
  removing "audio description viewed" and "receive all notifications"
- Reword Option B to "I don't want to receive notifications for any of
  the options above."
- Load/save each checkbox via its own backend field
  (opt_in_wishlist_published, opt_in_ai_feedback)
- Simplify checkbox state/handlers to the two-option model

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Profile page showed notification opt-in options, but the Save button wasn't wired to a backend endpoint, so nothing was stored. This connects the UI to persistence and simplifies the options to the set the product actually needs. Each checkbox maps to its own backend field, so a returning user sees exactly what they previously selected. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- End-to-end on the local site: with the API (:4001) and app (:3000) running, toggled the checkboxes and both radio options, saved, and confirmed choices round-trip — reloading restores the exact per-checkbox state.
- UI verification: rendered /profile/:userId in a headless browser — confirmed exactly two checkboxes (ids 0/1), removed options gone, correct Option B wording, and the hint rendering smaller and indented in line with the radio label.
- Type safety: npx tsc --noEmit passes cleanly.
- Save validation: confirmed selecting Option A with no checkbox still blocks save with the "not selected any opt-in checkbox" alert.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
