### PR TITLE
fix: ourFetch missing credentials caused 401 on protected routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,11 +142,26 @@ axios.interceptors.response.use(
   (error) => {
     if (error?.response?.status === 401) {
       userDataStore.getState().clearUserData()
-      toast.error('Your session has expired. Please sign in again.')
+      // xiao: toastId dedupes concurrent 401s (video page fires several requests at once);
+      // 5s instead of global 1s default for low-vision users
+      toast.error('Your session has expired. Please sign in again.', {
+        autoClose: 5000,
+        toastId: 'session-expired',
+      })
     }
     return Promise.reject(error)
   },
 )
+
+// xiao: ourFetch (XHR) bypasses the axios interceptor — listen for its 401 events here
+window.addEventListener('ydx:unauthorized', () => {
+  userDataStore.getState().clearUserData()
+  // xiao: same toastId as the axios interceptor — mixed axios/ourFetch 401s show one toast total
+  toast.error('Your session has expired. Please sign in again.', {
+    autoClose: 5000,
+    toastId: 'session-expired',
+  })
+})
 
 const App = () => {
   const { userId, userToken, userName, userPicture, clearUserData } =

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -6,6 +6,8 @@ import { translate, userDataStore } from '@/App'
 
 import { apiUrl } from '@/shared/config'
 
+import { toast } from 'react-toastify' // xiao: replace blocking alert() with toast for consistent UI
+
 interface ProfileParams {
   userId: string
 }
@@ -67,10 +69,12 @@ const Profile = () => {
 
   const handleSave = async () => {
     if (reviewStatus !== 'reviewed') {
-      alert('Sorry, you have not made any choice yet.')
+      // xiao: alert() replaced with toast — non-blocking, matches site-wide notification style
+      toast.error('Sorry, you have not made any choice yet.')
       return
     } else if (optIn && !optInChoices[0] && !optInChoices[1]) {
-      alert('Sorry, you have not selected any opt-in checkbox.')
+      // xiao: alert() replaced with toast — non-blocking, matches site-wide notification style
+      toast.error('Sorry, you have not selected any opt-in checkbox.')
       return
     }
     try {
@@ -86,9 +90,11 @@ const Profile = () => {
         }),
       }
       await ourFetch(url, true, optionObj)
-      alert(
-        'Your opt-in choices have been successfully saved! You will now be redirected to the home page',
-      )
+      // xiao: toast instead of blocking alert; 5s for low-vision users (global default is 1s).
+      // "redirected to home page" wording removed — toast doesn't block, navigate fires immediately
+      toast.success('Your opt-in choices have been successfully saved!', {
+        autoClose: 5000,
+      })
       navigate('/') // Redirect using useNavigate
     } catch (error) {
       console.error('Failed to save opt-in choices:', error)

--- a/src/shared/utils/ourFetch.ts
+++ b/src/shared/utils/ourFetch.ts
@@ -1,3 +1,5 @@
+import { apiUrl } from '../config'  // Xiao: import the apiUrl from the config file
+
 interface Response {
   code: number
   message: string
@@ -27,6 +29,9 @@ const ourFetch = (
 
     req.open(optionObj.method, absoluteUrl.toString())
 
+    // xiao: send session cookie only to YDX backend; third-party domains (googleapis) reject credentialed requests via CORS
+    req.withCredentials = absoluteUrl.origin === new URL(apiUrl).origin
+
     req.timeout = optionObj.timeoutMs ?? 15000
 
     req.ontimeout = () => {
@@ -51,6 +56,10 @@ const ourFetch = (
           resolve(req.response)
         }
       } else {
+        // xiao: notify app of session expiration — ourFetch bypasses the axios interceptor
+        if (req.status === 401) {
+          window.dispatchEvent(new CustomEvent('ydx:unauthorized'))
+        }
         try {
           reject(JSON.parse(req.response))
         } catch {

--- a/src/shared/utils/ourFetch.ts
+++ b/src/shared/utils/ourFetch.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from '../config'  // Xiao: import the apiUrl from the config file
+import { apiUrl } from '../config' // Xiao: import the apiUrl from the config file
 
 interface Response {
   code: number


### PR DESCRIPTION
## Description
After auth middleware was added (#116), ourFetch (XHR) requests failed with 401 — it never sent the session cookie. Affected 9 call sites: Profile save/load, ratings, feedback, wishlist upvote.

- ourFetch.ts: send credentials only to YDX backend origin; dispatch event on 401 (XHR bypasses axios interceptor)
- App.tsx: listen for the event; add toastId to dedupe concurrent 401 toasts; 5s autoClose for low-vision users
- Profile.tsx: replace blocking alert() with toast

## How has this been tested?
- Profile save/load: works, green toast + redirect
- Concurrent 401s: exactly one toast shown
- Search page: third-party (YouTube API) requests unaffected

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)