### PR TITLE
Promote dev to main: frontend auth credentials/interceptor + opt-in save UI + volume slider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer } from 'react-toastify' // for toast messages
+import { ToastContainer, toast } from 'react-toastify' // for toast messages
+import axios from 'axios'
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'
 import Home from './pages/Home/Home'
@@ -80,14 +81,20 @@ const resetCookie = () => {
   document.cookie = `userName=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
   document.cookie = `userPicture=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
 }
+
+// xiao: 0713
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
+
 interface UserStore {
   isSignedIn: boolean
+  authStatus: AuthStatus
   userId: string
   userToken: string
   userName: string
   userPicture: string
   userAdmin: number
   setSignedIn: (isSignedIn: boolean) => void
+  setAuthStatus: (authStatus: AuthStatus) => void
   setUserId: (userId: string) => void
   setUserToken: (userToken: string) => void
   setUserName: (userName: string) => void
@@ -99,12 +106,14 @@ interface UserStore {
 export const userDataStore = create<UserStore>()(
   devtools((set) => ({
     isSignedIn: false,
+    authStatus: 'loading',
     userId: '',
     userToken: '',
     userName: '',
     userPicture: '',
     userAdmin: 0,
     setSignedIn: (isSignedIn: boolean) => set({ isSignedIn }),
+    setAuthStatus: (authStatus: AuthStatus) => set({ authStatus }),
     setUserId: (userId: string) => set({ userId }),
     setUserToken: (userToken: string) => set({ userToken }),
     setUserName: (userName: string) => set({ userName }),
@@ -113,6 +122,7 @@ export const userDataStore = create<UserStore>()(
     clearUserData: () => {
       set({
         isSignedIn: false,
+        authStatus: 'unauthenticated',
         userId: '',
         userToken: '',
         userName: '',
@@ -123,6 +133,18 @@ export const userDataStore = create<UserStore>()(
       resetCookie()
     },
   })),
+)
+
+// Detect session expiration at runtime, if any Axios request returns 401, immediately treat the user as logged out
+axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error?.response?.status === 401) {
+      userDataStore.getState().clearUserData()
+      toast.error('Your session has expired. Please sign in again.')
+    }
+    return Promise.reject(error)
+  },
 )
 
 const App = () => {
@@ -141,6 +163,7 @@ const App = () => {
 
   const {
     setSignedIn,
+    setAuthStatus,
     setUserId,
     setUserToken,
     setUserName,
@@ -149,6 +172,7 @@ const App = () => {
   } = userDataStore((state) => {
     return {
       setSignedIn: state.setSignedIn,
+      setAuthStatus: state.setAuthStatus,
       setUserId: state.setUserId,
       setUserToken: state.setUserToken,
       setUserName: state.setUserName,
@@ -226,13 +250,21 @@ const App = () => {
       const response = await fetch(url, {
         credentials: 'include',
       })
+      if (!response.ok) {
+        clearUserData()
+        return
+      }
       const data = await response.json()
-
+      if (!data?.result) {
+        clearUserData()
+        return
+      }
       setUserData(data.result)
       handleRedirect()
     } catch (error) {
       //}
       console.error('Login error:', error)
+      clearUserData()
     }
   }
 
@@ -242,6 +274,7 @@ const App = () => {
     setUserId(result._id)
     setUserToken(result.token)
     setUserPicture(result.picture)
+    setAuthStatus('authenticated')
     setUserAdmin(result.admin)
     setSignedIn(true)
     setCookie(result._id, result.token, result.name, result.picture)
@@ -292,11 +325,11 @@ const App = () => {
     name: string,
     picture: string,
   ) => {
-    const now = new Date()
-    let time = now.getTime()
-    time += 20 * 1000
-    now.setTime(time)
-    const exp = now.toUTCString()
+    // const now = new Date()
+    // let time = now.getTime()
+    // time += 20 * 1000
+    // now.setTime(time)
+    // const exp = now.toUTCString()
     document.cookie = `userId=${id};path=/`
     document.cookie = `userToken=${token};path=/`
     document.cookie = `userName=${name};path=/`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,8 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer, toast } from 'react-toastify' // for toast messages
-import axios from 'axios'
+import { ToastContainer, toast } from 'react-toastify'  // xiao: toast used for session expiration notification
+import axios from 'axios' // xiao: axios imported for 401 response interceptor
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'
 import Home from './pages/Home/Home'
@@ -82,7 +82,7 @@ const resetCookie = () => {
   document.cookie = `userPicture=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
 }
 
-// xiao: 0713
+// xiao: three-state auth — 'loading' = haven't checked backend, 'authenticated' = confirmed, 'unauthenticated' = denied
 export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
 
 interface UserStore {
@@ -122,6 +122,7 @@ export const userDataStore = create<UserStore>()(
     clearUserData: () => {
       set({
         isSignedIn: false,
+        // xiao: explicitly mark as unauthenticated so UI knows backend denied login
         authStatus: 'unauthenticated',
         userId: '',
         userToken: '',
@@ -135,7 +136,7 @@ export const userDataStore = create<UserStore>()(
   })),
 )
 
-// Detect session expiration at runtime, if any Axios request returns 401, immediately treat the user as logged out
+// xiao: intercept all axios responses — any 401 means session expired, clear login state immediately
 axios.interceptors.response.use(
   (response) => response,
   (error) => {
@@ -250,11 +251,13 @@ const App = () => {
       const response = await fetch(url, {
         credentials: 'include',
       })
+      // xiao: backend returns 500 when not logged in, fetch doesn't throw on 500 — must check response.ok explicitly
       if (!response.ok) {
         clearUserData()
         return
       }
       const data = await response.json()
+      // xiao: safety check — 200 but no result means unexpected response, treat as not logged in
       if (!data?.result) {
         clearUserData()
         return
@@ -262,8 +265,8 @@ const App = () => {
       setUserData(data.result)
       handleRedirect()
     } catch (error) {
-      //}
       console.error('Login error:', error)
+      // xiao: network error — clear fake login state instead of silently ignoring
       clearUserData()
     }
   }
@@ -274,6 +277,7 @@ const App = () => {
     setUserId(result._id)
     setUserToken(result.token)
     setUserPicture(result.picture)
+    // xiao: backend confirmed login — set authoritative auth state
     setAuthStatus('authenticated')
     setUserAdmin(result.admin)
     setSignedIn(true)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,11 +142,26 @@ axios.interceptors.response.use(
   (error) => {
     if (error?.response?.status === 401) {
       userDataStore.getState().clearUserData()
-      toast.error('Your session has expired. Please sign in again.')
+      // xiao: toastId dedupes concurrent 401s (video page fires several requests at once);
+      // 5s instead of global 1s default for low-vision users
+      toast.error('Your session has expired. Please sign in again.', {
+        autoClose: 5000,
+        toastId: 'session-expired',
+      })
     }
     return Promise.reject(error)
   },
 )
+
+// xiao: ourFetch (XHR) bypasses the axios interceptor — listen for its 401 events here
+window.addEventListener('ydx:unauthorized', () => {
+  userDataStore.getState().clearUserData()
+  // xiao: same toastId as the axios interceptor — mixed axios/ourFetch 401s show one toast total
+  toast.error('Your session has expired. Please sign in again.', {
+    autoClose: 5000,
+    toastId: 'session-expired',
+  })
+})
 
 const App = () => {
   const { userId, userToken, userName, userPicture, clearUserData } =

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer, toast } from 'react-toastify'  // xiao: toast used for session expiration notification
+import { ToastContainer, toast } from 'react-toastify' // xiao: toast used for session expiration notification
 import axios from 'axios' // xiao: axios imported for 401 response interceptor
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'

--- a/src/features/Describe/AudioClip/AudioClip.tsx
+++ b/src/features/Describe/AudioClip/AudioClip.tsx
@@ -62,6 +62,7 @@ interface Props {
   setEnrollInCollabEdit: (val: boolean) => void
   onPublish: (e: any, checkbox?: boolean) => void
   isTutorialMode?: boolean
+  descriptionVolume?: number
 }
 
 const AudioClip = ({
@@ -91,6 +92,7 @@ const AudioClip = ({
   setEnrollInCollabEdit,
   onPublish,
   isTutorialMode = false,
+  descriptionVolume,
 }: Props) => {
   const clipID = clip.clip_id
   const clipSequenceNumber = clip.clip_sequence_number
@@ -575,6 +577,7 @@ const AudioClip = ({
               setUndoDeletedClip={setUndoDeletedClip}
               setClipDescText={handleDescriptionChange}
               isTutorialMode={isTutorialMode}
+              descriptionVolume={descriptionVolume}
             />
           )}
         </div>

--- a/src/features/Describe/EditClip/EditClip.tsx
+++ b/src/features/Describe/EditClip/EditClip.tsx
@@ -11,6 +11,11 @@ import convertSecondsToCardFormat from '../../../shared/utils/convertSecondsToCa
 import padNumber from '@/shared/utils/padNumber'
 import { Tooltip } from 'bootstrap'
 import { TUTORIAL_TARGETS } from '../../Tutorial/tutorialSelectors'
+import {
+  attachAudioElementToGain,
+  howlerVolumeFor,
+  setDescriptionAmplification,
+} from '@/shared/utils/descriptionGain'
 
 interface Props {
   userId: string
@@ -38,6 +43,7 @@ interface Props {
   handleClickSaveClipDescription: (updatedClipDescriptionText: string) => void
   setClipDescText: (description: string) => void
   isTutorialMode?: boolean
+  descriptionVolume?: number
 }
 
 const EditClip = ({
@@ -66,8 +72,10 @@ const EditClip = ({
   setUndoDeletedClip,
   setClipDescText,
   isTutorialMode = false,
+  descriptionVolume = 100,
 }: Props) => {
   const ref = useRef<HTMLDivElement>(null)
+  const recordedAudioElRef = useRef<HTMLAudioElement>(null)
   const clipEndTime = clipStartTime + clipDuration
 
   const [clipDescriptionText, setClipDescriptionText] = useState(
@@ -200,8 +208,11 @@ const EditClip = ({
     setClipDescriptionText(initialClipDescriptionText ?? '')
     handleClipStartTimeInputsRender()
     handleClipEndTimeInputsRender()
-    if (mediaBlobUrl !== null) {
-      const newAudio = new Audio(mediaBlobUrl)
+    if (mediaBlobUrl != null) {
+      const newAudio = new Audio()
+      newAudio.crossOrigin = 'anonymous'
+      newAudio.src = mediaBlobUrl
+      newAudio.volume = howlerVolumeFor(descriptionVolume)
       setRecordedAudio(newAudio)
       newAudio.addEventListener(
         'loadedmetadata',
@@ -225,7 +236,11 @@ const EditClip = ({
         false,
       )
     }
-    setAdAudio(new Audio(clipAudioPath))
+    const initialAdAudio = new Audio()
+    initialAdAudio.crossOrigin = 'anonymous'
+    initialAdAudio.src = clipAudioPath
+    initialAdAudio.volume = howlerVolumeFor(descriptionVolume)
+    setAdAudio(initialAdAudio)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     clipAudioPath,
@@ -247,10 +262,25 @@ const EditClip = ({
 
   useEffect(() => {
     if (clipAudioPath && !isRecorded) {
-      const newAudio = new Audio(clipAudioPath)
+      const newAudio = new Audio()
+      newAudio.crossOrigin = 'anonymous'
+      newAudio.src = clipAudioPath
+      newAudio.volume = howlerVolumeFor(descriptionVolume)
       setAdAudio(newAudio)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clipAudioPath, isRecorded])
+
+  // Keep every preview-audio element in sync with the shared Description Volume
+  // slider so recorded-voice and TTS clips duck together, matching the video
+  // overlay playback path in Video_v2 / useAudioDescriptionEngine.
+  useEffect(() => {
+    setDescriptionAmplification(descriptionVolume)
+    const v = howlerVolumeFor(descriptionVolume)
+    if (adAudio) adAudio.volume = v
+    if (recordedAudio) recordedAudio.volume = v
+    if (recordedAudioElRef.current) recordedAudioElRef.current.volume = v
+  }, [descriptionVolume, adAudio, recordedAudio])
 
   useEffect(() => {
     let interval: NodeJS.Timeout | null = null
@@ -431,6 +461,11 @@ const EditClip = ({
       recordedAudio?.pause()
       setIsRecordedAudioPlaying(false)
     } else {
+      if (recordedAudio) {
+        recordedAudio.volume = howlerVolumeFor(descriptionVolume)
+        setDescriptionAmplification(descriptionVolume)
+        attachAudioElementToGain(recordedAudio)
+      }
       recordedAudio?.play()
       setIsRecordedAudioPlaying(true)
       recordedAudio?.addEventListener('ended', function () {
@@ -445,6 +480,11 @@ const EditClip = ({
       adAudio?.pause()
       setIsAdAudioPlaying(false)
     } else {
+      if (adAudio) {
+        adAudio.volume = howlerVolumeFor(descriptionVolume)
+        setDescriptionAmplification(descriptionVolume)
+        attachAudioElementToGain(adAudio)
+      }
       const audioProm = adAudio?.play()
       if (audioProm !== undefined) {
         audioProm
@@ -747,7 +787,15 @@ const EditClip = ({
                     <i className="fa fa-check-circle text-success"></i>
                     <span>Recording completed! Listen and confirm:</span>
                   </div>
-                  <audio src={mediaBlobUrl} controls className="w-100 mb-3" />
+                  <audio
+                    ref={recordedAudioElRef}
+                    src={mediaBlobUrl}
+                    controls
+                    className="w-100 mb-3"
+                    onLoadedMetadata={(e) => {
+                      e.currentTarget.volume = descriptionVolume / 100
+                    }}
+                  />
                   <div className="confirmation-actions">
                     <button
                       className="ydx-button ydx-button--success"

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -11,11 +11,7 @@ interface ProfileParams {
 }
 
 const Profile = () => {
-  const [optInChoices, setOptInChoices] = useState<boolean[]>([
-    false,
-    false,
-    false,
-  ])
+  const [optInChoices, setOptInChoices] = useState<boolean[]>([false, false])
   const [optIn, setOptIn] = useState<boolean>(false)
   const [reviewStatus, setReviewStatus] = useState<string>('')
 
@@ -33,12 +29,14 @@ const Profile = () => {
       const url = `${apiUrl}/users/${userId}`
       const response = await ourFetch(url)
       const user = response.result
-      const choices = [false, false, false]
-      user.opt_in.forEach((index: number) => {
-        choices[index] = true
-      })
+      // Each checkbox is persisted in its own field. choices[0] = wishlist
+      // published, choices[1] = automated AI feedback.
+      const choices = [
+        user.opt_in_wishlist_published === true,
+        user.opt_in_ai_feedback === true,
+      ]
       setOptInChoices(choices)
-      setOptIn(user.opt_in.length > 0)
+      setOptIn(user.opt_in === true)
       setReviewStatus(user.policy_review)
     } catch (error) {
       console.error('Failed to load user data:', error)
@@ -47,14 +45,8 @@ const Profile = () => {
 
   const handleCheckBoxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const index = parseInt(event.target.id)
-    let choices = [...optInChoices]
-    if (index === 3) {
-      choices = event.target.checked
-        ? [true, true, true]
-        : [false, false, false]
-    } else {
-      choices[index] = event.target.checked
-    }
+    const choices = [...optInChoices]
+    choices[index] = event.target.checked
     setOptInChoices(choices)
     setOptIn(true)
     setReviewStatus('reviewed')
@@ -65,7 +57,7 @@ const Profile = () => {
   ) => {
     const value = event.target.value
     if (value === 'off') {
-      setOptInChoices([false, false, false])
+      setOptInChoices([false, false])
       setOptIn(false)
     } else {
       setOptIn(true)
@@ -77,12 +69,7 @@ const Profile = () => {
     if (reviewStatus !== 'reviewed') {
       alert('Sorry, you have not made any choice yet.')
       return
-    } else if (
-      optIn &&
-      !optInChoices[0] &&
-      !optInChoices[1] &&
-      !optInChoices[2]
-    ) {
+    } else if (optIn && !optInChoices[0] && !optInChoices[1]) {
       alert('Sorry, you have not selected any opt-in checkbox.')
       return
     }
@@ -131,51 +118,48 @@ const Profile = () => {
           value="on"
           onChange={handleRadioButtonChange}
         />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[0]}
-          name="optinchoices"
-          label={translate(
-            'My wishlist selection has been described and published',
-          )}
-          id="0"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[1]}
-          name="optinchoices"
-          label={translate('My audio description has been viewed')}
-          id="1"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[2]}
-          name="optinchoices"
-          label={translate(
-            'I wish to receive automated feedback on my published audio descriptions',
-          )}
-          id="2"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices.every((choice) => choice)}
-          label={translate('I would like to receive all notifications')}
-          id="3"
-          onChange={handleCheckBoxChange}
-        />
+        <p
+          id="optin-required-hint"
+          className="optin-helper-text"
+          style={{ marginLeft: '1.5em', fontSize: '0.85rem' }}
+        >
+          {translate('(Please select at least one option below)')}
+        </p>
+        <div
+          role="group"
+          aria-label={translate('A. Yes I want to be notified by email when:')}
+          aria-required={optIn}
+          aria-describedby={optIn ? 'optin-required-hint' : undefined}
+        >
+          <Form.Check
+            style={{ marginLeft: 20 }}
+            type="checkbox"
+            checked={optInChoices[0]}
+            name="optinchoices"
+            label={translate(
+              'My wishlist selection has been described and published',
+            )}
+            id="0"
+            onChange={handleCheckBoxChange}
+          />
+          <Form.Check
+            style={{ marginLeft: 20 }}
+            type="checkbox"
+            checked={optInChoices[1]}
+            name="optinchoices"
+            label={translate(
+              'I wish to receive automated feedback on my published audio descriptions',
+            )}
+            id="1"
+            onChange={handleCheckBoxChange}
+          />
+        </div>
         <br />
         <Form.Check
           type="radio"
           checked={reviewStatus === 'reviewed' && !optIn}
           label={translate(
-            'B. I do not want any automated notifications from YouDescribe.',
+            "B. I don't want to receive notifications for any of the options above.",
           )}
           name="optin"
           value="off"

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -6,6 +6,8 @@ import { translate, userDataStore } from '@/App'
 
 import { apiUrl } from '@/shared/config'
 
+import { toast } from 'react-toastify' // xiao: replace blocking alert() with toast for consistent UI
+
 interface ProfileParams {
   userId: string
 }
@@ -67,10 +69,12 @@ const Profile = () => {
 
   const handleSave = async () => {
     if (reviewStatus !== 'reviewed') {
-      alert('Sorry, you have not made any choice yet.')
+      // xiao: alert() replaced with toast — non-blocking, matches site-wide notification style
+      toast.error('Sorry, you have not made any choice yet.')
       return
     } else if (optIn && !optInChoices[0] && !optInChoices[1]) {
-      alert('Sorry, you have not selected any opt-in checkbox.')
+      // xiao: alert() replaced with toast — non-blocking, matches site-wide notification style
+      toast.error('Sorry, you have not selected any opt-in checkbox.')
       return
     }
     try {
@@ -86,9 +90,11 @@ const Profile = () => {
         }),
       }
       await ourFetch(url, true, optionObj)
-      alert(
-        'Your opt-in choices have been successfully saved! You will now be redirected to the home page',
-      )
+      // xiao: toast instead of blocking alert; 5s for low-vision users (global default is 1s).
+      // "redirected to home page" wording removed — toast doesn't block, navigate fires immediately
+      toast.success('Your opt-in choices have been successfully saved!', {
+        autoClose: 5000,
+      })
       navigate('/') // Redirect using useNavigate
     } catch (error) {
       console.error('Failed to save opt-in choices:', error)

--- a/src/pages/Video/Video.tsx
+++ b/src/pages/Video/Video.tsx
@@ -170,7 +170,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
   } = useAudioDescriptionEngine(
     audioClips,
     currentEventRef.current,
-    descriptionVolumeRef.current,
+    descriptionVolume,
     descriptionsActive && currentState === 1,
   )
 
@@ -237,12 +237,50 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
   }, [currentState])
 
   useEffect(() => {
-    if (currentEventRef) {
-      currentEventRef.current?.setVolume(youTubeVolume)
+    descriptionVolumeRef.current = descriptionVolume
+    localStorage.setItem('descriptionVolume', descriptionVolume.toString())
+  }, [descriptionVolume])
+
+  useEffect(() => {
+    const player = currentEventRef.current
+    if (player) {
+      if (youTubeVolume === 0) {
+        player.mute?.()
+      } else {
+        player.unMute?.()
+        player.setVolume?.(youTubeVolume)
+      }
     }
     youTubeVolumeRef.current = youTubeVolume
     localStorage.setItem('youTubeVolume', youTubeVolume.toString())
-  }, [youTubeVolume, currentEventRef])
+  }, [youTubeVolume])
+
+  // The YouTube iframe API doesn't emit volume/mute events, so poll the
+  // player and mirror external changes (e.g. clicking YouTube's built-in
+  // mute button) back into our slider state.
+  useEffect(() => {
+    if (!currentEvent) return
+    let cancelled = false
+    const id = setInterval(async () => {
+      try {
+        const [muted, vol] = await Promise.all([
+          currentEvent.isMuted?.() ?? Promise.resolve(false),
+          currentEvent.getVolume?.() ?? Promise.resolve(100),
+        ])
+        if (cancelled) return
+        const effective = muted ? 0 : Math.round(vol)
+        if (effective !== youTubeVolumeRef.current) {
+          setYouTubeVolume(effective)
+        }
+      } catch {
+        // player not ready yet
+      }
+    }, 500)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [currentEvent])
 
   useEffect(() => {
     return () => {
@@ -254,13 +292,6 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
       })
     }
   }, [audioClips])
-
-  useEffect(() => {
-    currentEventRef.current = currentEvent
-    if (currentEvent) {
-      currentEvent.setVolume(youTubeVolume)
-    }
-  }, [currentEvent, youTubeVolume])
 
   useEffect(() => {
     if (currentState !== 1 || audioClips.length === 0) return
@@ -1622,7 +1653,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
                 {describerCards.slice(1)}
                 <Button
                   title={translate('Turn off descriptions for this video')}
-                  text={translate('Turn Off Descriptions')}
+                  text={translate('Turn off descriptions')}
                   color="w3-indigo w3-block w3-margin-top"
                   ariaLabel="Turn off descriptions for this video"
                   onClick={handleTurnOffDescriptions}

--- a/src/pages/YDXHome.tsx
+++ b/src/pages/YDXHome.tsx
@@ -38,6 +38,10 @@ import { useTutorialEditorAdapter } from '../features/Tutorial/useTutorialEditor
 import type { TutorialMode } from '../features/Tutorial/tutorialStepRegistry'
 import { useAudioDescriptionEngine } from '../shared/hooks/useAudioDescriptionEngine' // <-- Add import
 import { invalidateHomeVideoCache } from '../shared/utils/homeVideoCache'
+import {
+  howlerVolumeFor,
+  setDescriptionAmplification,
+} from '../shared/utils/descriptionGain'
 
 type DialogTimestamp = {
   dialog_seq_no: number
@@ -277,6 +281,19 @@ const YDXHome = ({
   useEffect(() => {
     currentClipIndexRef.current = currentClipIndex
   }, [currentClipIndex])
+
+  // Description Volume slider — keep the ref in sync, persist across sessions,
+  // and update every preloaded Howl in the current clip stack so a slider
+  // change ducks TTS and voice-recorded clips even before they start playing.
+  useEffect(() => {
+    descriptionVolumeRef.current = descriptionVolume
+    localStorage.setItem('descriptionVolume', descriptionVolume.toString())
+    setDescriptionAmplification(descriptionVolume)
+    const v = howlerVolumeFor(descriptionVolume)
+    clipStackRef.current.forEach((clip) => {
+      if (clip.clip_audio) clip.clip_audio.volume(v)
+    })
+  }, [descriptionVolume])
 
   useEffect(() => {
     navClipIndexRef.current = navClipIndex
@@ -617,6 +634,7 @@ const YDXHome = ({
       html5: true,
       preload: true,
       autoplay: false,
+      volume: descriptionVolumeRef.current / 100,
     })
     clip.clip_audio.load()
     return clip
@@ -825,6 +843,7 @@ const YDXHome = ({
               html5: true,
               preload: true,
               autoplay: false,
+              volume: descriptionVolumeRef.current / 100,
             })
             clip.clip_audio.load()
             clipStackData.push(clip)
@@ -1164,6 +1183,7 @@ const YDXHome = ({
           html5: true,
           preload: true,
           autoplay: false,
+          volume: descriptionVolumeRef.current / 100,
         })
         clip.clip_audio.load()
         clipStackData.push(clip)
@@ -1789,6 +1809,7 @@ const YDXHome = ({
               setEnrollInCollabEdit={setEnrollInCollabEdit}
               onPublish={handlePublish}
               isTutorialMode={isTutorialMode}
+              descriptionVolume={descriptionVolume}
             />
           )}
         </div>

--- a/src/shared/components/Navbar/Navbar.tsx
+++ b/src/shared/components/Navbar/Navbar.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   const location = useLocation()
-  const authStatus = userDataStore((s) => s.authStatus)
+  const authStatus = userDataStore((s) => s.authStatus) // xiao: reactive subscription — re-renders when auth state changes
 
   const navMenuOpen = () => {
     const mySidenav = document.getElementById('mySidenav')
@@ -43,6 +43,7 @@ const Navbar = ({ newGoogleAuth, signOut }: Props) => {
     }
   }
 
+  // xiao: three-state rendering — nothing while checking, avatar when confirmed, sign-in button when denied
   const signInComponent = () => {
     if (authStatus === 'loading') {
       return null

--- a/src/shared/components/Navbar/Navbar.tsx
+++ b/src/shared/components/Navbar/Navbar.tsx
@@ -13,6 +13,7 @@ interface Props {
 
 const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   const location = useLocation()
+  const authStatus = userDataStore((s) => s.authStatus)
 
   const navMenuOpen = () => {
     const mySidenav = document.getElementById('mySidenav')
@@ -43,11 +44,13 @@ const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   }
 
   const signInComponent = () => {
-    if (userDataStore.getState().isSignedIn) {
-      return <UserAvatar userMenuToggle={userMenuToggle} signOut={signOut} />
-    } else {
-      return <SignInButton newGoogleAuth={newGoogleAuth} />
+    if (authStatus === 'loading') {
+      return null
     }
+    if (authStatus === 'authenticated') {
+      return <UserAvatar userMenuToggle={userMenuToggle} signOut={signOut} />
+    }
+    return <SignInButton newGoogleAuth={newGoogleAuth} />
   }
   const myHistoryUrl = `/videos/history`
 

--- a/src/shared/components/VideoPlayerControls/VideoPlayerControls.tsx
+++ b/src/shared/components/VideoPlayerControls/VideoPlayerControls.tsx
@@ -1,6 +1,7 @@
 import { debounce } from 'debounce'
-import { ChangeEvent, useMemo, useState } from 'react'
+import { ChangeEvent, useEffect, useMemo, useState } from 'react'
 import Form from 'react-bootstrap/Form'
+import { DESCRIPTION_VOLUME_MAX } from '@/shared/utils/descriptionGain'
 import './videoPlayerControls.scss'
 
 interface Props {
@@ -19,6 +20,16 @@ const VideoPlayerControls = ({
   const [descriptionValue, setDescriptionValue] =
     useState<number>(descriptionVolume)
   const [YTValue, setYTValue] = useState<number>(youTubeVideoVolume)
+
+  // Keep the visible slider positions in lockstep with the parent-owned
+  // volume state, so external changes (e.g. clicking YouTube's built-in
+  // mute button) move the sliders too.
+  useEffect(() => {
+    setDescriptionValue(descriptionVolume)
+  }, [descriptionVolume])
+  useEffect(() => {
+    setYTValue(youTubeVideoVolume)
+  }, [youTubeVideoVolume])
 
   // const showAudioDuckingTooltip = (props: any) => {
   //   return (
@@ -95,8 +106,11 @@ const VideoPlayerControls = ({
           <div className="col-sm-6 col-md-6 col-lg-6">
             <Form.Range
               aria-label="Audio Description Volume Slider"
-              aria-roledescription="This slider controls the volume of the audio description. The volume can be adjusted from 0 to 100."
+              aria-roledescription={`Slider for audio description volume. 0 is muted, 100 is the recorded level, and ${DESCRIPTION_VOLUME_MAX} amplifies quiet recordings up to 3x.`}
               className=""
+              min={0}
+              max={DESCRIPTION_VOLUME_MAX}
+              step={1}
               value={descriptionValue}
               onChange={handleDescriptionVolumeChange}
             />

--- a/src/shared/hooks/useAudioDescriptionEngine.tsx
+++ b/src/shared/hooks/useAudioDescriptionEngine.tsx
@@ -2,6 +2,11 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { Howl } from 'howler'
 import axios from 'axios'
 import { Clip } from '@/shared/utils/convertClipObject'
+import {
+  attachHowlToGain,
+  howlerVolumeFor,
+  setDescriptionAmplification,
+} from '@/shared/utils/descriptionGain'
 
 type EngineState =
   | 'IDLE'
@@ -54,6 +59,10 @@ export const useAudioDescriptionEngine = (
         engineStateRef.current = 'PLAYING_INLINE'
       }
 
+      // Volume 0-100 on the slider maps to Howler's 0.0-1.0; anything above 100
+      // is delivered via the shared Web Audio GainNode (see descriptionGain.ts).
+      const howlVolume = howlerVolumeFor(descriptionVolume)
+
       // Assign to a variable and ensure it is treated as a Howl instance
       const howlInstance: Howl =
         clip.clip_audio ??
@@ -61,8 +70,16 @@ export const useAudioDescriptionEngine = (
           src: clip.clip_audio_path,
           html5: true,
           preload: true,
-          volume: descriptionVolume / 100,
+          volume: howlVolume,
         })
+
+      // Preloaded Howl instances (created by pages like YDXHome/Video_v2 before
+      // playback) don't carry the current slider volume, and the `??` above uses
+      // them as-is. Set volume explicitly on every playback so the Description
+      // Volume slider affects TTS and voice-recorded clips uniformly.
+      howlInstance.volume(howlVolume)
+      setDescriptionAmplification(descriptionVolume)
+      attachHowlToGain(howlInstance)
 
       // Use howlInstance consistently within this scope
       howlInstance.once('play', () => {
@@ -192,8 +209,9 @@ export const useAudioDescriptionEngine = (
 
   // 7. Sync & Lifecycle
   useEffect(() => {
+    setDescriptionAmplification(descriptionVolume)
     if (currentAudioRef.current)
-      currentAudioRef.current.volume(descriptionVolume / 100)
+      currentAudioRef.current.volume(howlerVolumeFor(descriptionVolume))
   }, [descriptionVolume])
 
   useEffect(() => {

--- a/src/shared/utils/descriptionGain.ts
+++ b/src/shared/utils/descriptionGain.ts
@@ -1,0 +1,123 @@
+import { Howl, Howler } from 'howler'
+
+// Description Volume slider is 0-300. Values in 0-100 map to Howler's built-in
+// per-clip volume (0.0-1.0); values 100-300 hold Howler at 1.0 and drive a
+// Web Audio GainNode from 1.0 up to 3.0 to amplify quiet recordings.
+export const DESCRIPTION_VOLUME_MAX = 300
+export const DESCRIPTION_VOLUME_UNITY = 100
+
+export const howlerVolumeFor = (slider: number): number =>
+  Math.min(Math.max(slider, 0), DESCRIPTION_VOLUME_UNITY) /
+  DESCRIPTION_VOLUME_UNITY
+
+export const amplificationFor = (slider: number): number =>
+  Math.max(slider, DESCRIPTION_VOLUME_UNITY) / DESCRIPTION_VOLUME_UNITY
+
+let audioContext: AudioContext | null = null
+let ampGain: GainNode | null = null
+const attached = new WeakSet<HTMLMediaElement>()
+
+// Howler's html5 audio pool creates plain `new Audio()` elements without
+// setting crossOrigin. Once we route an element through a MediaElementSource,
+// its output would be silenced by CORS on cross-origin sources unless
+// crossOrigin was set BEFORE the src was assigned. Patch _obtainHtml5Audio
+// at import time so every audio element leaves the pool with
+// crossOrigin='anonymous' — this must run before any Howl is created.
+const anyHowler = (Howler ?? {}) as unknown as {
+  _obtainHtml5Audio?: () => HTMLAudioElement
+}
+const originalObtain = anyHowler._obtainHtml5Audio
+if (typeof originalObtain === 'function') {
+  anyHowler._obtainHtml5Audio = function (...args: unknown[]) {
+    const node = (
+      originalObtain as unknown as (...a: unknown[]) => HTMLAudioElement
+    ).apply(this, args)
+    if (node && !node.crossOrigin) node.crossOrigin = 'anonymous'
+    return node
+  }
+}
+
+const ensureContext = (): { ctx: AudioContext; gain: GainNode } | null => {
+  if (audioContext && ampGain) return { ctx: audioContext, gain: ampGain }
+  const AC =
+    (typeof window !== 'undefined' &&
+      (window.AudioContext ||
+        (window as unknown as { webkitAudioContext?: typeof AudioContext })
+          .webkitAudioContext)) ||
+    null
+  if (!AC) return null
+  try {
+    audioContext = new AC()
+    ampGain = audioContext.createGain()
+    ampGain.gain.value = 1
+    ampGain.connect(audioContext.destination)
+    return { ctx: audioContext, gain: ampGain }
+  } catch {
+    return null
+  }
+}
+
+export const setDescriptionAmplification = (sliderValue: number): void => {
+  const ready = ensureContext()
+  if (!ready) return
+  const target = amplificationFor(sliderValue)
+  try {
+    ready.gain.gain.setTargetAtTime(target, ready.ctx.currentTime, 0.015)
+  } catch {
+    ready.gain.gain.value = target
+  }
+}
+
+const wireElement = (
+  ctx: AudioContext,
+  gain: GainNode,
+  node: HTMLMediaElement,
+): void => {
+  if (attached.has(node)) return
+  const audioNode = node as HTMLAudioElement
+  if (!audioNode.crossOrigin) {
+    audioNode.crossOrigin = 'anonymous'
+  }
+  try {
+    const source = ctx.createMediaElementSource(node)
+    source.connect(gain)
+    attached.add(node)
+  } catch {
+    // createMediaElementSource can throw if this element was already
+    // attached to a different context. Fall back to native playback
+    // (no amplification for this element); .volume still works.
+  }
+}
+
+// Attach the underlying HTMLAudioElement of a Howl instance to the shared
+// gain node. Safe to call repeatedly; each element is wired at most once.
+export const attachHowlToGain = (howl: Howl): void => {
+  const ready = ensureContext()
+  if (!ready) return
+  if (ready.ctx.state === 'suspended') {
+    ready.ctx.resume().catch(() => undefined)
+  }
+  const sounds = (
+    howl as unknown as { _sounds?: Array<{ _node?: HTMLMediaElement }> }
+  )._sounds
+  if (!sounds || !sounds.length) return
+  for (const sound of sounds) {
+    const node = sound?._node
+    if (!node) continue
+    wireElement(ready.ctx, ready.gain, node)
+  }
+}
+
+// Attach a raw HTMLMediaElement (e.g. an edit-panel preview created with
+// `new Audio(...)`) to the shared gain node.
+export const attachAudioElementToGain = (
+  node: HTMLMediaElement | null | undefined,
+): void => {
+  if (!node) return
+  const ready = ensureContext()
+  if (!ready) return
+  if (ready.ctx.state === 'suspended') {
+    ready.ctx.resume().catch(() => undefined)
+  }
+  wireElement(ready.ctx, ready.gain, node)
+}

--- a/src/shared/utils/ourFetch.ts
+++ b/src/shared/utils/ourFetch.ts
@@ -1,3 +1,5 @@
+import { apiUrl } from '../config'  // Xiao: import the apiUrl from the config file
+
 interface Response {
   code: number
   message: string
@@ -27,6 +29,9 @@ const ourFetch = (
 
     req.open(optionObj.method, absoluteUrl.toString())
 
+    // xiao: send session cookie only to YDX backend; third-party domains (googleapis) reject credentialed requests via CORS
+    req.withCredentials = absoluteUrl.origin === new URL(apiUrl).origin
+
     req.timeout = optionObj.timeoutMs ?? 15000
 
     req.ontimeout = () => {
@@ -51,6 +56,10 @@ const ourFetch = (
           resolve(req.response)
         }
       } else {
+        // xiao: notify app of session expiration — ourFetch bypasses the axios interceptor
+        if (req.status === 401) {
+          window.dispatchEvent(new CustomEvent('ydx:unauthorized'))
+        }
         try {
           reject(JSON.parse(req.response))
         } catch {

--- a/src/shared/utils/ourFetch.ts
+++ b/src/shared/utils/ourFetch.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from '../config'  // Xiao: import the apiUrl from the config file
+import { apiUrl } from '../config' // Xiao: import the apiUrl from the config file
 
 interface Response {
   code: number


### PR DESCRIPTION
## Summary

Promotes 4 features merged to dev in July. **Two of these are the frontend companions to the auth middleware (#116) that already shipped to prod on the api side today** — promoting them closes a deployment-ordering gap.

### #176 — ourFetch credentials fix (Xiao) ⚠️ ordering-critical
- `ourFetch` was not sending session credentials, so now that the api enforces auth (401 on ~35 protected routes via api #116, already on prod), logged-in users can hit 401 on protected routes. This adds credentials so the session cookie is sent.
- Also converts raw `alert()` to toast.

### #174 — auth three-state + 401 interceptor (Xiao)
- Frontend half of the silent-logout fix: distinguishes logged-in / logged-out / unknown, and adds a 401 interceptor so an expired session redirects to login instead of failing silently. Pairs with the api 401 mapping.

### #175 — opt-in save button UI (Hedy)
- Wires the notification opt-in save button to `POST /users/updateoptin` (api endpoint already on prod).
- Reduces Option A to two checkboxes (wishlist-published + automated AI feedback), matching the two new backend fields `opt_in_wishlist_published` / `opt_in_ai_feedback`.

### #173 — description volume slider (Kien)
- Description volume slider works end-to-end with 3x amplification and mute sync. Adds `descriptionGain.ts`.

## Deploy notes

- Reverse diff (`dev...main`) is empty — clean merge, no conflicts.
- Recommend promoting promptly: api #116 auth enforcement is live on prod but the frontend credentials fix (#176) is not, so prod logged-in users may currently see 401s on protected routes until this ships.