### PR TITLE
Promote to main: frontend auth credentials/interceptor (#174, #176) + opt-in save UI (#175)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer } from 'react-toastify' // for toast messages
+import { ToastContainer, toast } from 'react-toastify' // for toast messages
+import axios from 'axios'
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'
 import Home from './pages/Home/Home'
@@ -80,14 +81,20 @@ const resetCookie = () => {
   document.cookie = `userName=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
   document.cookie = `userPicture=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
 }
+
+// xiao: 0713
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
+
 interface UserStore {
   isSignedIn: boolean
+  authStatus: AuthStatus
   userId: string
   userToken: string
   userName: string
   userPicture: string
   userAdmin: number
   setSignedIn: (isSignedIn: boolean) => void
+  setAuthStatus: (authStatus: AuthStatus) => void
   setUserId: (userId: string) => void
   setUserToken: (userToken: string) => void
   setUserName: (userName: string) => void
@@ -99,12 +106,14 @@ interface UserStore {
 export const userDataStore = create<UserStore>()(
   devtools((set) => ({
     isSignedIn: false,
+    authStatus: 'loading',
     userId: '',
     userToken: '',
     userName: '',
     userPicture: '',
     userAdmin: 0,
     setSignedIn: (isSignedIn: boolean) => set({ isSignedIn }),
+    setAuthStatus: (authStatus: AuthStatus) => set({ authStatus }),
     setUserId: (userId: string) => set({ userId }),
     setUserToken: (userToken: string) => set({ userToken }),
     setUserName: (userName: string) => set({ userName }),
@@ -113,6 +122,7 @@ export const userDataStore = create<UserStore>()(
     clearUserData: () => {
       set({
         isSignedIn: false,
+        authStatus: 'unauthenticated',
         userId: '',
         userToken: '',
         userName: '',
@@ -123,6 +133,18 @@ export const userDataStore = create<UserStore>()(
       resetCookie()
     },
   })),
+)
+
+// Detect session expiration at runtime, if any Axios request returns 401, immediately treat the user as logged out
+axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error?.response?.status === 401) {
+      userDataStore.getState().clearUserData()
+      toast.error('Your session has expired. Please sign in again.')
+    }
+    return Promise.reject(error)
+  },
 )
 
 const App = () => {
@@ -141,6 +163,7 @@ const App = () => {
 
   const {
     setSignedIn,
+    setAuthStatus,
     setUserId,
     setUserToken,
     setUserName,
@@ -149,6 +172,7 @@ const App = () => {
   } = userDataStore((state) => {
     return {
       setSignedIn: state.setSignedIn,
+      setAuthStatus: state.setAuthStatus,
       setUserId: state.setUserId,
       setUserToken: state.setUserToken,
       setUserName: state.setUserName,
@@ -226,13 +250,21 @@ const App = () => {
       const response = await fetch(url, {
         credentials: 'include',
       })
+      if (!response.ok) {
+        clearUserData()
+        return
+      }
       const data = await response.json()
-
+      if (!data?.result) {
+        clearUserData()
+        return
+      }
       setUserData(data.result)
       handleRedirect()
     } catch (error) {
       //}
       console.error('Login error:', error)
+      clearUserData()
     }
   }
 
@@ -242,6 +274,7 @@ const App = () => {
     setUserId(result._id)
     setUserToken(result.token)
     setUserPicture(result.picture)
+    setAuthStatus('authenticated')
     setUserAdmin(result.admin)
     setSignedIn(true)
     setCookie(result._id, result.token, result.name, result.picture)
@@ -292,11 +325,11 @@ const App = () => {
     name: string,
     picture: string,
   ) => {
-    const now = new Date()
-    let time = now.getTime()
-    time += 20 * 1000
-    now.setTime(time)
-    const exp = now.toUTCString()
+    // const now = new Date()
+    // let time = now.getTime()
+    // time += 20 * 1000
+    // now.setTime(time)
+    // const exp = now.toUTCString()
     document.cookie = `userId=${id};path=/`
     document.cookie = `userToken=${token};path=/`
     document.cookie = `userName=${name};path=/`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,8 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer, toast } from 'react-toastify' // for toast messages
-import axios from 'axios'
+import { ToastContainer, toast } from 'react-toastify'  // xiao: toast used for session expiration notification
+import axios from 'axios' // xiao: axios imported for 401 response interceptor
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'
 import Home from './pages/Home/Home'
@@ -82,7 +82,7 @@ const resetCookie = () => {
   document.cookie = `userPicture=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
 }
 
-// xiao: 0713
+// xiao: three-state auth — 'loading' = haven't checked backend, 'authenticated' = confirmed, 'unauthenticated' = denied
 export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
 
 interface UserStore {
@@ -122,6 +122,7 @@ export const userDataStore = create<UserStore>()(
     clearUserData: () => {
       set({
         isSignedIn: false,
+        // xiao: explicitly mark as unauthenticated so UI knows backend denied login
         authStatus: 'unauthenticated',
         userId: '',
         userToken: '',
@@ -135,7 +136,7 @@ export const userDataStore = create<UserStore>()(
   })),
 )
 
-// Detect session expiration at runtime, if any Axios request returns 401, immediately treat the user as logged out
+// xiao: intercept all axios responses — any 401 means session expired, clear login state immediately
 axios.interceptors.response.use(
   (response) => response,
   (error) => {
@@ -250,11 +251,13 @@ const App = () => {
       const response = await fetch(url, {
         credentials: 'include',
       })
+      // xiao: backend returns 500 when not logged in, fetch doesn't throw on 500 — must check response.ok explicitly
       if (!response.ok) {
         clearUserData()
         return
       }
       const data = await response.json()
+      // xiao: safety check — 200 but no result means unexpected response, treat as not logged in
       if (!data?.result) {
         clearUserData()
         return
@@ -262,8 +265,8 @@ const App = () => {
       setUserData(data.result)
       handleRedirect()
     } catch (error) {
-      //}
       console.error('Login error:', error)
+      // xiao: network error — clear fake login state instead of silently ignoring
       clearUserData()
     }
   }
@@ -274,6 +277,7 @@ const App = () => {
     setUserId(result._id)
     setUserToken(result.token)
     setUserPicture(result.picture)
+    // xiao: backend confirmed login — set authoritative auth state
     setAuthStatus('authenticated')
     setUserAdmin(result.admin)
     setSignedIn(true)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,11 +142,26 @@ axios.interceptors.response.use(
   (error) => {
     if (error?.response?.status === 401) {
       userDataStore.getState().clearUserData()
-      toast.error('Your session has expired. Please sign in again.')
+      // xiao: toastId dedupes concurrent 401s (video page fires several requests at once);
+      // 5s instead of global 1s default for low-vision users
+      toast.error('Your session has expired. Please sign in again.', {
+        autoClose: 5000,
+        toastId: 'session-expired',
+      })
     }
     return Promise.reject(error)
   },
 )
+
+// xiao: ourFetch (XHR) bypasses the axios interceptor — listen for its 401 events here
+window.addEventListener('ydx:unauthorized', () => {
+  userDataStore.getState().clearUserData()
+  // xiao: same toastId as the axios interceptor — mixed axios/ourFetch 401s show one toast total
+  toast.error('Your session has expired. Please sign in again.', {
+    autoClose: 5000,
+    toastId: 'session-expired',
+  })
+})
 
 const App = () => {
   const { userId, userToken, userName, userPicture, clearUserData } =

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import UserStudyHome from './pages/UserStudyHome'
 import PlayVideo from './pages/PlayVideo'
 import './assets/css/index.css'
 import './app.scss'
-import { ToastContainer, toast } from 'react-toastify'  // xiao: toast used for session expiration notification
+import { ToastContainer, toast } from 'react-toastify' // xiao: toast used for session expiration notification
 import axios from 'axios' // xiao: axios imported for 401 response interceptor
 import 'react-toastify/dist/ReactToastify.css'
 import LogRocket from 'logrocket'

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -11,11 +11,7 @@ interface ProfileParams {
 }
 
 const Profile = () => {
-  const [optInChoices, setOptInChoices] = useState<boolean[]>([
-    false,
-    false,
-    false,
-  ])
+  const [optInChoices, setOptInChoices] = useState<boolean[]>([false, false])
   const [optIn, setOptIn] = useState<boolean>(false)
   const [reviewStatus, setReviewStatus] = useState<string>('')
 
@@ -33,12 +29,14 @@ const Profile = () => {
       const url = `${apiUrl}/users/${userId}`
       const response = await ourFetch(url)
       const user = response.result
-      const choices = [false, false, false]
-      user.opt_in.forEach((index: number) => {
-        choices[index] = true
-      })
+      // Each checkbox is persisted in its own field. choices[0] = wishlist
+      // published, choices[1] = automated AI feedback.
+      const choices = [
+        user.opt_in_wishlist_published === true,
+        user.opt_in_ai_feedback === true,
+      ]
       setOptInChoices(choices)
-      setOptIn(user.opt_in.length > 0)
+      setOptIn(user.opt_in === true)
       setReviewStatus(user.policy_review)
     } catch (error) {
       console.error('Failed to load user data:', error)
@@ -47,14 +45,8 @@ const Profile = () => {
 
   const handleCheckBoxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const index = parseInt(event.target.id)
-    let choices = [...optInChoices]
-    if (index === 3) {
-      choices = event.target.checked
-        ? [true, true, true]
-        : [false, false, false]
-    } else {
-      choices[index] = event.target.checked
-    }
+    const choices = [...optInChoices]
+    choices[index] = event.target.checked
     setOptInChoices(choices)
     setOptIn(true)
     setReviewStatus('reviewed')
@@ -65,7 +57,7 @@ const Profile = () => {
   ) => {
     const value = event.target.value
     if (value === 'off') {
-      setOptInChoices([false, false, false])
+      setOptInChoices([false, false])
       setOptIn(false)
     } else {
       setOptIn(true)
@@ -77,12 +69,7 @@ const Profile = () => {
     if (reviewStatus !== 'reviewed') {
       alert('Sorry, you have not made any choice yet.')
       return
-    } else if (
-      optIn &&
-      !optInChoices[0] &&
-      !optInChoices[1] &&
-      !optInChoices[2]
-    ) {
+    } else if (optIn && !optInChoices[0] && !optInChoices[1]) {
       alert('Sorry, you have not selected any opt-in checkbox.')
       return
     }
@@ -131,51 +118,48 @@ const Profile = () => {
           value="on"
           onChange={handleRadioButtonChange}
         />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[0]}
-          name="optinchoices"
-          label={translate(
-            'My wishlist selection has been described and published',
-          )}
-          id="0"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[1]}
-          name="optinchoices"
-          label={translate('My audio description has been viewed')}
-          id="1"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices[2]}
-          name="optinchoices"
-          label={translate(
-            'I wish to receive automated feedback on my published audio descriptions',
-          )}
-          id="2"
-          onChange={handleCheckBoxChange}
-        />
-        <Form.Check
-          style={{ marginLeft: 20 }}
-          type="checkbox"
-          checked={optInChoices.every((choice) => choice)}
-          label={translate('I would like to receive all notifications')}
-          id="3"
-          onChange={handleCheckBoxChange}
-        />
+        <p
+          id="optin-required-hint"
+          className="optin-helper-text"
+          style={{ marginLeft: '1.5em', fontSize: '0.85rem' }}
+        >
+          {translate('(Please select at least one option below)')}
+        </p>
+        <div
+          role="group"
+          aria-label={translate('A. Yes I want to be notified by email when:')}
+          aria-required={optIn}
+          aria-describedby={optIn ? 'optin-required-hint' : undefined}
+        >
+          <Form.Check
+            style={{ marginLeft: 20 }}
+            type="checkbox"
+            checked={optInChoices[0]}
+            name="optinchoices"
+            label={translate(
+              'My wishlist selection has been described and published',
+            )}
+            id="0"
+            onChange={handleCheckBoxChange}
+          />
+          <Form.Check
+            style={{ marginLeft: 20 }}
+            type="checkbox"
+            checked={optInChoices[1]}
+            name="optinchoices"
+            label={translate(
+              'I wish to receive automated feedback on my published audio descriptions',
+            )}
+            id="1"
+            onChange={handleCheckBoxChange}
+          />
+        </div>
         <br />
         <Form.Check
           type="radio"
           checked={reviewStatus === 'reviewed' && !optIn}
           label={translate(
-            'B. I do not want any automated notifications from YouDescribe.',
+            "B. I don't want to receive notifications for any of the options above.",
           )}
           name="optin"
           value="off"

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -6,6 +6,8 @@ import { translate, userDataStore } from '@/App'
 
 import { apiUrl } from '@/shared/config'
 
+import { toast } from 'react-toastify' // xiao: replace blocking alert() with toast for consistent UI
+
 interface ProfileParams {
   userId: string
 }
@@ -67,10 +69,12 @@ const Profile = () => {
 
   const handleSave = async () => {
     if (reviewStatus !== 'reviewed') {
-      alert('Sorry, you have not made any choice yet.')
+      // xiao: alert() replaced with toast — non-blocking, matches site-wide notification style
+      toast.error('Sorry, you have not made any choice yet.')
       return
     } else if (optIn && !optInChoices[0] && !optInChoices[1]) {
-      alert('Sorry, you have not selected any opt-in checkbox.')
+      // xiao: alert() replaced with toast — non-blocking, matches site-wide notification style
+      toast.error('Sorry, you have not selected any opt-in checkbox.')
       return
     }
     try {
@@ -86,9 +90,11 @@ const Profile = () => {
         }),
       }
       await ourFetch(url, true, optionObj)
-      alert(
-        'Your opt-in choices have been successfully saved! You will now be redirected to the home page',
-      )
+      // xiao: toast instead of blocking alert; 5s for low-vision users (global default is 1s).
+      // "redirected to home page" wording removed — toast doesn't block, navigate fires immediately
+      toast.success('Your opt-in choices have been successfully saved!', {
+        autoClose: 5000,
+      })
       navigate('/') // Redirect using useNavigate
     } catch (error) {
       console.error('Failed to save opt-in choices:', error)

--- a/src/shared/components/Navbar/Navbar.tsx
+++ b/src/shared/components/Navbar/Navbar.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   const location = useLocation()
-  const authStatus = userDataStore((s) => s.authStatus)
+  const authStatus = userDataStore((s) => s.authStatus) // xiao: reactive subscription — re-renders when auth state changes
 
   const navMenuOpen = () => {
     const mySidenav = document.getElementById('mySidenav')
@@ -43,6 +43,7 @@ const Navbar = ({ newGoogleAuth, signOut }: Props) => {
     }
   }
 
+  // xiao: three-state rendering — nothing while checking, avatar when confirmed, sign-in button when denied
   const signInComponent = () => {
     if (authStatus === 'loading') {
       return null

--- a/src/shared/components/Navbar/Navbar.tsx
+++ b/src/shared/components/Navbar/Navbar.tsx
@@ -13,6 +13,7 @@ interface Props {
 
 const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   const location = useLocation()
+  const authStatus = userDataStore((s) => s.authStatus)
 
   const navMenuOpen = () => {
     const mySidenav = document.getElementById('mySidenav')
@@ -43,11 +44,13 @@ const Navbar = ({ newGoogleAuth, signOut }: Props) => {
   }
 
   const signInComponent = () => {
-    if (userDataStore.getState().isSignedIn) {
-      return <UserAvatar userMenuToggle={userMenuToggle} signOut={signOut} />
-    } else {
-      return <SignInButton newGoogleAuth={newGoogleAuth} />
+    if (authStatus === 'loading') {
+      return null
     }
+    if (authStatus === 'authenticated') {
+      return <UserAvatar userMenuToggle={userMenuToggle} signOut={signOut} />
+    }
+    return <SignInButton newGoogleAuth={newGoogleAuth} />
   }
   const myHistoryUrl = `/videos/history`
 

--- a/src/shared/utils/ourFetch.ts
+++ b/src/shared/utils/ourFetch.ts
@@ -1,3 +1,5 @@
+import { apiUrl } from '../config'  // Xiao: import the apiUrl from the config file
+
 interface Response {
   code: number
   message: string
@@ -27,6 +29,9 @@ const ourFetch = (
 
     req.open(optionObj.method, absoluteUrl.toString())
 
+    // xiao: send session cookie only to YDX backend; third-party domains (googleapis) reject credentialed requests via CORS
+    req.withCredentials = absoluteUrl.origin === new URL(apiUrl).origin
+
     req.timeout = optionObj.timeoutMs ?? 15000
 
     req.ontimeout = () => {
@@ -51,6 +56,10 @@ const ourFetch = (
           resolve(req.response)
         }
       } else {
+        // xiao: notify app of session expiration — ourFetch bypasses the axios interceptor
+        if (req.status === 401) {
+          window.dispatchEvent(new CustomEvent('ydx:unauthorized'))
+        }
         try {
           reject(JSON.parse(req.response))
         } catch {

--- a/src/shared/utils/ourFetch.ts
+++ b/src/shared/utils/ourFetch.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from '../config'  // Xiao: import the apiUrl from the config file
+import { apiUrl } from '../config' // Xiao: import the apiUrl from the config file
 
 interface Response {
   code: number


### PR DESCRIPTION
## Summary

Selective promotion of three dev PRs to main, **excluding** the description-volume-slider work (#173), which stays on dev for now.

Cherry-picked (verified: this branch differs from `dev` only in #173's files, and differs from `main` only in these three PRs' files — App.tsx, Profile.tsx, Navbar.tsx, ourFetch.ts):

### #176 — ourFetch credentials fix (Xiao) ⚠️ ordering-critical
- `ourFetch` was not sending session credentials. With the api auth middleware (#116) already enforcing 401 on ~35 protected routes in prod, logged-in users can hit 401 on protected routes until this ships. Adds credentials so the session cookie is sent; also converts raw `alert()` to toast.

### #174 — auth three-state + 401 interceptor (Xiao)
- Distinguishes logged-in / logged-out / unknown and adds a 401 interceptor so an expired session redirects to login instead of failing silently. Frontend companion to the api 401 mapping.

### #175 — opt-in save button UI (Hedy)
- Wires the notification opt-in save button to `POST /users/updateoptin` (api endpoint already on prod).
- Reduces Option A to two checkboxes (wishlist-published + automated AI feedback), matching backend fields `opt_in_wishlist_published` / `opt_in_ai_feedback`.

## Notes

- #173 (description volume slider) deliberately left off this PR.
- Recommend prompt merge: api #116 auth enforcement is live on prod but the frontend credentials fix (#176) is not, so prod logged-in users may currently see 401s on protected routes until this ships.