### PR TITLE
Added email notification opt-in note to profile page

### DIFF
--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -109,6 +109,15 @@ const Profile = () => {
             'YouDescribe is now using an optional email notification system. In the form below, please select your desired notification options. These can be changed later in the My Profile tab, found in your user menu.',
           )}
         </p>
+        <p
+          id="optin-ai-status-note"
+          className="optin-note-text"
+          style={{ fontSize: '0.9rem' }}
+        >
+          {translate(
+            'Note: emails about the status of your AI description requests (processing and completed) cannot be turned off, and are not affected by the choices below.',
+          )}
+        </p>
         <Form.Check
           type="radio"
           checked={reviewStatus === 'reviewed' && optIn}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Adds a short note to the Profile page's email-notification opt-in form clarifying that emails about AI description request status (queued/processing/completed) are not controlled by the opt-in checkboxes on that page and cannot be disabled.

## Motivation and Context
The two checkboxes on this page only gate the "wishlist published" and "AI feedback received" notifications (opt_in_wishlist_published / opt_in_ai_feedback). The AI-description request/status emails are sent unconditionally by the backend (requestAiDescriptionsWithLana → performImmediateOperations in users.service.ts) regardless of these settings. Users opting out of all notifications on this page could reasonably assume it also stops those emails, so this note sets that expectation correctly.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually verified locally: loaded the Profile page and confirmed the note renders above the opt-in radio/checkbox group, alongside end-to-end testing this session of the related wishlist-published and feedback-notification email triggers (backend logs confirmed sendEmail firing correctly for both, with emails received in the test inbox). No automated tests cover this page currently.


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
