### PR TITLE
fix(tutorial): align AI tutorial with tab order

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
     "format:win": "prettier --write \"./**/*.{js,jsx,ts,tsx,css,md,json}\" --config .prettierrc",
     "prepare": "husky install"
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1"
+    }
+  },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/src/features/Describe/NewAudioClip/NewAudioClip.tsx
+++ b/src/features/Describe/NewAudioClip/NewAudioClip.tsx
@@ -38,7 +38,7 @@ const NewAudioClipComponent = ({
   const [isRecording, setIsRecording] = useState(false)
   const [recordingError, setRecordingError] = useState<string | null>(null)
   const [descriptionMethod, setDescriptionMethod] = useState<'text' | 'audio'>(
-    'audio',
+    tutorialMode ? 'text' : 'audio',
   )
   const [recordingDuration, setRecordingDuration] = useState(0)
   const [readySetGo, setReadySetGo] = useState('')

--- a/src/features/Tutorial/TutorialPage.tsx
+++ b/src/features/Tutorial/TutorialPage.tsx
@@ -42,6 +42,7 @@ const TutorialPage = () => {
     isActive,
     activeSteps,
     currentStepIndex,
+    navigationSource,
     goToStep,
   })
 

--- a/src/features/Tutorial/tutorialAiStepSequence.ts
+++ b/src/features/Tutorial/tutorialAiStepSequence.ts
@@ -120,17 +120,6 @@ export const aiPostForkSteps: TutorialStep[] = [
     uiState: SAVED_CLIP,
   }),
 
-  withUIStateDefaultScroll(insertInlineBtnStep, SAVED_CLIP, {
-    id: 'ai-insert-inline-add-more',
-  }),
-  withUIState(insertExtendedBtnStep, SAVED_CLIP, { id: 'ai-insert-extended-add-more' }),
-  withUIState(currentClipNavigatorStep, SAVED_CLIP, {
-    id: 'ai-clip-currently-editing-add-more',
-  }),
-  withUIState(clipNavButtonsStep, SAVED_CLIP, {
-    id: 'ai-clip-nav-buttons-add-more',
-  }),
-
   withUIState(clipFormIntroStep, FORM_AND_CLIP, {
     id: 'ai-clip-form-intro',
     title: 'Insert Audio Clip',

--- a/src/features/Tutorial/tutorialAiStepSequence.ts
+++ b/src/features/Tutorial/tutorialAiStepSequence.ts
@@ -50,6 +50,12 @@ const aiEditorIntroStep = centeredStep({
 export const aiPostForkSteps: TutorialStep[] = [
   aiEditorIntroStep,
 
+  withUIStateDefaultScroll(playPauseBtnStep, SAVED_CLIP, {
+    id: 'ai-play-pause',
+  }),
+  withUIState(audioDuckingStep, SAVED_CLIP, { id: 'ai-audio-ducking' }),
+  withUIState(notesAreaStep, SAVED_CLIP, { id: 'ai-notes-area' }),
+  
   withUIState(dialogTimelineStep, SAVED_CLIP, {
     id: 'ai-dialog-timeline',
     content:
@@ -60,28 +66,28 @@ export const aiPostForkSteps: TutorialStep[] = [
       { label: 'Blue', description: 'Video dialogue', color: 'dialogue' },
     ],
   }),
-
-  withUIStateDefaultScroll(playPauseBtnStep, SAVED_CLIP, {
-    id: 'ai-play-pause',
+  withUIStateDefaultScroll(insertInlineBtnStep, SAVED_CLIP, {
+    id: 'ai-insert-inline',
   }),
-  withUIState(notesAreaStep, SAVED_CLIP, { id: 'ai-notes-area' }),
-  withUIState(audioDuckingStep, SAVED_CLIP, { id: 'ai-audio-ducking' }),
-
+  withUIState(insertExtendedBtnStep, SAVED_CLIP, { id: 'ai-insert-extended' }),
+  withUIState(currentClipNavigatorStep, SAVED_CLIP, {
+    id: 'ai-clip-currently-editing',
+  }),
+  withUIState(savedClipsListStep, SAVED_CLIP_WITH_LIST, {
+    id: 'ai-saved-clips-list',
+    waitForTargetSettle: true,
+  }),
+  withUIState(clipNavButtonsStep, SAVED_CLIP, {
+    id: 'ai-clip-nav-buttons',
+  }),
+  
   withUIStateDefaultScroll(clipControlsStep, SAVED_CLIP, {
     id: 'ai-clip-controls',
     title: 'Review AI Clip',
     content:
       'You can view AI-generated clips here. Edit the content, timing, or type as needed.',
   }),
-  withUIState(clipAiVoiceStep, SAVED_CLIP, {
-    id: 'ai-clip-ai-voice',
-    title: 'AI Description Content',
-    content:
-      'Edit the AI-generated text, preview the audio, or record your own voice instead.',
-  }),
-  withUIState(clipTimingControlsStep, SAVED_CLIP, { id: 'ai-clip-timing' }),
   withUIState(nudgeControlsStep, SAVED_CLIP, { id: 'ai-nudge-controls' }),
-
   {
     id: 'ai-clip-type',
     targetSelector: getTutorialSelector(TUTORIAL_TARGETS.aiClipType),
@@ -94,6 +100,13 @@ export const aiPostForkSteps: TutorialStep[] = [
     autoScroll: false,
     uiState: SAVED_CLIP,
   },
+  withUIState(clipAiVoiceStep, SAVED_CLIP, {
+    id: 'ai-clip-ai-voice',
+    title: 'AI Description Content',
+    content:
+      'Edit the AI-generated text, preview the audio, or record your own voice instead.',
+  }),
+  withUIState(clipTimingControlsStep, SAVED_CLIP, { id: 'ai-clip-timing' }),
 
   centeredStep({
     id: 'ai-add-more-intro',
@@ -108,9 +121,16 @@ export const aiPostForkSteps: TutorialStep[] = [
   }),
 
   withUIStateDefaultScroll(insertInlineBtnStep, SAVED_CLIP, {
-    id: 'ai-insert-inline',
+    id: 'ai-insert-inline-add-more',
   }),
-  withUIState(insertExtendedBtnStep, SAVED_CLIP, { id: 'ai-insert-extended' }),
+  withUIState(insertExtendedBtnStep, SAVED_CLIP, { id: 'ai-insert-extended-add-more' }),
+  withUIState(currentClipNavigatorStep, SAVED_CLIP, {
+    id: 'ai-clip-currently-editing-add-more',
+  }),
+  withUIState(clipNavButtonsStep, SAVED_CLIP, {
+    id: 'ai-clip-nav-buttons-add-more',
+  }),
+
   withUIState(clipFormIntroStep, FORM_AND_CLIP, {
     id: 'ai-clip-form-intro',
     title: 'Insert Audio Clip',
@@ -127,18 +147,7 @@ export const aiPostForkSteps: TutorialStep[] = [
     content: 'Add your own description or supplement the AI-generated ones.',
   }),
   withUIState(saveBtnStep, FORM_AND_CLIP, { id: 'ai-save-btn' }),
-
-  withUIState(currentClipNavigatorStep, SAVED_CLIP, {
-    id: 'ai-clip-currently-editing',
-  }),
-  withUIState(savedClipsListStep, SAVED_CLIP_WITH_LIST, {
-    id: 'ai-saved-clips-list',
-    waitForTargetSettle: true,
-  }),
-  withUIState(clipNavButtonsStep, SAVED_CLIP, {
-    id: 'ai-clip-nav-buttons',
-  }),
-
+  
   withUIStateDefaultScroll(collabCheckboxStep, SAVED_CLIP, {
     id: 'ai-collab',
   }),

--- a/src/features/Tutorial/tutorialAiStepSequence.ts
+++ b/src/features/Tutorial/tutorialAiStepSequence.ts
@@ -55,7 +55,7 @@ export const aiPostForkSteps: TutorialStep[] = [
   }),
   withUIState(audioDuckingStep, SAVED_CLIP, { id: 'ai-audio-ducking' }),
   withUIState(notesAreaStep, SAVED_CLIP, { id: 'ai-notes-area' }),
-  
+
   withUIState(dialogTimelineStep, SAVED_CLIP, {
     id: 'ai-dialog-timeline',
     content:
@@ -80,7 +80,7 @@ export const aiPostForkSteps: TutorialStep[] = [
   withUIState(clipNavButtonsStep, SAVED_CLIP, {
     id: 'ai-clip-nav-buttons',
   }),
-  
+
   withUIStateDefaultScroll(clipControlsStep, SAVED_CLIP, {
     id: 'ai-clip-controls',
     title: 'Review AI Clip',
@@ -136,7 +136,7 @@ export const aiPostForkSteps: TutorialStep[] = [
     content: 'Add your own description or supplement the AI-generated ones.',
   }),
   withUIState(saveBtnStep, FORM_AND_CLIP, { id: 'ai-save-btn' }),
-  
+
   withUIStateDefaultScroll(collabCheckboxStep, SAVED_CLIP, {
     id: 'ai-collab',
   }),

--- a/src/features/Tutorial/useTutorialKeyboardFlow.ts
+++ b/src/features/Tutorial/useTutorialKeyboardFlow.ts
@@ -55,10 +55,10 @@ export const useTutorialKeyboardFlow = ({
   goToStep,
 }: Params) => {
   const ignoreNextProgrammaticFocusRef = useRef(false)
-    useEffect(() => {
-  ignoreNextProgrammaticFocusRef.current =
-    navigationSource === 'tutorial-controls'
-}, [currentStepIndex, navigationSource])
+  useEffect(() => {
+    ignoreNextProgrammaticFocusRef.current =
+      navigationSource === 'tutorial-controls'
+  }, [currentStepIndex, navigationSource])
   useEffect(() => {
     if (!isActive) return undefined
 
@@ -67,9 +67,9 @@ export const useTutorialKeyboardFlow = ({
       if (!(element instanceof Element)) return
       if (element.closest('[data-tutorial-overlay="true"]')) return
       if (ignoreNextProgrammaticFocusRef.current) {
-  ignoreNextProgrammaticFocusRef.current = false
-  return
-}
+        ignoreNextProgrammaticFocusRef.current = false
+        return
+      }
 
       const matchingIndex = getClosestMatchingStepIndex(element, activeSteps)
 

--- a/src/features/Tutorial/useTutorialKeyboardFlow.ts
+++ b/src/features/Tutorial/useTutorialKeyboardFlow.ts
@@ -1,10 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { TutorialStep } from './tutorialStepRegistry'
 
 interface Params {
   isActive: boolean
   activeSteps: TutorialStep[]
   currentStepIndex: number
+  navigationSource: 'tutorial-controls' | 'page-tab'
   goToStep: (index: number, source: 'page-tab') => void
 }
 
@@ -50,8 +51,14 @@ export const useTutorialKeyboardFlow = ({
   isActive,
   activeSteps,
   currentStepIndex,
+  navigationSource,
   goToStep,
 }: Params) => {
+  const ignoreNextProgrammaticFocusRef = useRef(false)
+    useEffect(() => {
+  ignoreNextProgrammaticFocusRef.current =
+    navigationSource === 'tutorial-controls'
+}, [currentStepIndex, navigationSource])
   useEffect(() => {
     if (!isActive) return undefined
 
@@ -59,6 +66,10 @@ export const useTutorialKeyboardFlow = ({
       const element = event.target
       if (!(element instanceof Element)) return
       if (element.closest('[data-tutorial-overlay="true"]')) return
+      if (ignoreNextProgrammaticFocusRef.current) {
+  ignoreNextProgrammaticFocusRef.current = false
+  return
+}
 
       const matchingIndex = getClosestMatchingStepIndex(element, activeSteps)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reorders the AI tutorial steps to follow the interface's tab order. Also updates the tutorial navigation behavior to prevent programmatic focus from skipping and flashing steps and defaults the tutorial clip form to TTS so the description text step is available.

## Motivation and Context

The AI tutorial previously displayed an inconsistent order. Programmatic focus could also skip or flash some steps, and the Write Your Description couldn't appear and screen would be stuck.

## How has this been tested?

Locally tested.
Verified:
- The tutorial follows the updated step order.
- Insert Audio Clip is no longer flashed.
- Description Method defaults to TTS so that the tutorial continues to Write Your Description.
- Next and Previous navigation work correctly without getting stuck.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
