### PR TITLE
Use solid color for floating tutorial help button

### DIFF
--- a/src/features/Tutorial/tutorial.scss
+++ b/src/features/Tutorial/tutorial.scss
@@ -7,6 +7,7 @@ $tutorial-shadow-elevated: 0 4px 20px rgba(0, 0, 0, 0.3);
 $tutorial-visibility-transition: opacity 0.2s ease-out, visibility 0.2s;
 
 $tutorial-flow-gradient: linear-gradient(270deg, #1c3557, #4a90e2, #1c3557);
+$tutorial-float-solid: #2d5a8e;
 $tutorial-flow-shadow-soft: 0 4px 12px rgba(74, 144, 226, 0.2);
 $tutorial-flow-shadow-strong: 0 4px 15px rgba(74, 144, 226, 0.3);
 
@@ -358,7 +359,9 @@ $tutorial-focus-white: #fff;
   bottom: 24px;
   right: 24px;
   z-index: $tutorial-float-z-index;
-  @include tutorial-flow-background;
+  background: $tutorial-float-solid;
+  color: white;
+  border: none;
   border-radius: 28px;
   padding: 12px 24px;
   font-size: 14px;


### PR DESCRIPTION
## What

Replaces the animated gradient background on the floating "Learn how to describe" tutorial button with a solid color.

- New `$tutorial-float-solid: #2d5a8e` (midpoint of the previous gradient's endpoints `#1c3557` / `#4a90e2`)
- `.tutorial-float-btn` no longer includes the `tutorial-flow-background` mixin, which also removes the 6s `liquidFlow` animation on this button
- Hover scale/glow and focus outline are unchanged
- Other `tutorial-flow-background` usages (tutorial flow buttons) are untouched

## Why

The animated gradient made the always-visible floating button more distracting than helpful; a solid color keeps it noticeable but calm.

## Test

Verified locally: button renders solid #2d5a8e on pages where it shows, hidden routes unaffected, sass compiles clean.