### PR TITLE
Hedy/video rating change

### DIFF
--- a/src/features/Video/DescriberCard/DescriberCard.tsx
+++ b/src/features/Video/DescriberCard/DescriberCard.tsx
@@ -14,7 +14,8 @@ interface Props {
   handleDescriberChange: (describerId: string) => void
   handleRating: (rating: number) => void
   handleRatingPopup: () => void
-  handleFeedbackPopup: () => void
+  // Optional feedback UI disabled — data field (`feedback`) kept on the rating payload.
+  // handleFeedbackPopup: () => void
   handleNewCollabEdit: (describerId: string) => void
   videoId?: string
   collaborativeEdit?: boolean
@@ -31,7 +32,7 @@ const DescriberCard = ({
   handleDescriberChange,
   handleRating,
   handleRatingPopup,
-  handleFeedbackPopup,
+  // handleFeedbackPopup,
   handleNewCollabEdit,
   videoId,
   collaborativeEdit,
@@ -60,6 +61,7 @@ const DescriberCard = ({
             color="w3-indigo w3-block w3-margin-top"
             onClick={() => handleRatingPopup()}
           />
+          {/* Optional feedback UI disabled — data field (`feedback`) kept on the rating payload.
           <Button
             ariaLabel={translate('Provide feedback for this describer')}
             title={translate('Provide feedback for this describer')}
@@ -67,6 +69,7 @@ const DescriberCard = ({
             color="w3-indigo w3-block w3-margin-top"
             onClick={() => handleFeedbackPopup()}
           />
+          */}
           {collaborativeEdit && (
             <Button
               ariaLabel={translate(

--- a/src/features/Video/DescriberCard/DescriberCard.tsx
+++ b/src/features/Video/DescriberCard/DescriberCard.tsx
@@ -23,6 +23,19 @@ interface Props {
   displayContributions?: { [key: string]: number }
 }
 
+/**
+ * Accessible name for the star widget, applied via role="img" + aria-label.
+ *
+ * The average blends comprehension and enjoyment, so it lands on halves —
+ * reported to one decimal rather than rounded to the number of filled stars.
+ */
+const getRatingLabel = (average: number): string => {
+  if (average === null || average === undefined || Number.isNaN(average)) {
+    return 'no ratings'
+  }
+  return `${Math.round(average * 10) / 10} out of 5 star rating`
+}
+
 const DescriberCard = ({
   picture,
   name,
@@ -40,6 +53,11 @@ const DescriberCard = ({
   displayContributions, // Add this new prop
 }: Props) => {
   const navigate = useNavigate()
+
+  const ratingLabel = getRatingLabel(overall_rating_average)
+  // Unique per card so each describer's button describes its own rating.
+  const ratingLabelId = `describer-rating-${describerId}`
+
   const getButton = (): ReactNode => {
     const userName = userDataStore.getState().userName
     const isDescriber = name === userName
@@ -56,6 +74,7 @@ const DescriberCard = ({
         <>
           <Button
             ariaLabel={translate("Rate this describer's audio description")}
+            ariaDescribedBy={ratingLabelId}
             title={translate("Rate this describer's audio description")}
             text={translate('Rate Description')}
             color="w3-indigo w3-block w3-margin-top"
@@ -87,6 +106,7 @@ const DescriberCard = ({
     return (
       <Button
         ariaLabel={translate("Select this describer's audio description")}
+        ariaDescribedBy={ratingLabelId}
         title={translate("Select this describer's audio description")}
         text={translate('Use description')}
         color="w3-indigo w3-block"
@@ -96,28 +116,29 @@ const DescriberCard = ({
   }
 
   const getStars = (): ReactNode[] => {
-    const stars: ReactNode[] = []
-    for (let i = 0; i < 5; i += 1) {
-      if (i + 1 <= Math.round(overall_rating_average)) {
-        stars.push(
-          <button
-            key={i}
-            style={{ color: 'gold' }}
-            onClick={() => handleRating(5 - i)}
-            tabIndex={-1}
-          >
-            ★
-          </button>,
-        )
-      } else {
-        stars.push(
-          <button key={i} onClick={() => handleRating(5 - i)} tabIndex={-1}>
-            ★
-          </button>,
-        )
-      }
+    // Snapped to the nearest half so a 4.5 average is visually distinct from a
+    // perfect 5, matching the decimal the screen-reader label reports.
+    const snapped = Math.round(overall_rating_average * 2) / 2
+    const fullStars = Math.floor(snapped)
+    // NaN comparisons are all false, so an absent average leaves every star grey.
+    const halfIndex = snapped > fullStars ? fullStars : -1
+
+    const starClass = (index: number): string | undefined => {
+      if (index < fullStars) return 'star-full'
+      if (index === halfIndex) return 'star-half'
+      return undefined
     }
-    return stars
+
+    return Array.from({ length: 5 }, (unused, i) => (
+      <button
+        key={i}
+        className={starClass(i)}
+        onClick={() => handleRating(5 - i)}
+        tabIndex={-1}
+      >
+        ★
+      </button>
+    ))
   }
 
   const getDisplayedName = (): string => {
@@ -193,14 +214,22 @@ const DescriberCard = ({
               </div>
               <div className="w3-col l9 m7 s9">
                 {getDisplayedName()}
-                <div className="rating-desc" aria-hidden="true">
+                {/* role="img" + aria-label makes the star row itself the
+                    accessible node. Its descendants are dropped from the tree
+                    automatically, so the individual stars need no aria-hidden. */}
+                <div
+                  className="rating-desc"
+                  role="img"
+                  aria-label={ratingLabel}
+                >
                   {getStars()}
                 </div>
-                <div className="skip">
-                  {Number.isNaN(Math.round(overall_rating_average))
-                    ? 'no ratings'
-                    : `${Math.round(overall_rating_average)} star rating`}
-                </div>
+                {/* aria-describedby reads the target's text, not its aria-label,
+                    so the buttons point here rather than at the star row —
+                    otherwise the description comes out as "★ ★ ★ ★ ★". */}
+                <span className="visually-hidden" id={ratingLabelId}>
+                  {ratingLabel}
+                </span>
               </div>
             </>
           )}
@@ -210,14 +239,16 @@ const DescriberCard = ({
                 <Accordion.Header>{getDisplayedName()}</Accordion.Header>
                 <Accordion.Body>
                   {/* <div className="w3-col l12 m12 s12"> */}
-                  <div className="rating-desc" aria-hidden="true">
+                  <div
+                    className="rating-desc"
+                    role="img"
+                    aria-label={ratingLabel}
+                  >
                     {getStars()}
                   </div>
-                  <div className="skip">
-                    {Number.isNaN(Math.round(overall_rating_average))
-                      ? 'no ratings'
-                      : `${Math.round(overall_rating_average)} star rating`}
-                  </div>
+                  <span className="visually-hidden" id={ratingLabelId}>
+                    {ratingLabel}
+                  </span>
                   {renderContributionBars()}
                   <hr aria-hidden="true" />
                   {getButton()}

--- a/src/features/Video/DescriberCard/describerCard.scss
+++ b/src/features/Video/DescriberCard/describerCard.scss
@@ -15,6 +15,20 @@
       cursor: pointer;
       pointer-events: none;
     }
+
+    .star-full {
+      color: gold;
+    }
+
+    // Clipping a gradient to the glyph fills exactly half the star; no single
+    // Unicode half-star character renders reliably across fonts. Overrides the
+    // button's background-color, which is fine since the card behind is white.
+    .star-half {
+      background: linear-gradient(90deg, gold 50%, grey 50%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+    }
   }
 
   .contribution-bars {

--- a/src/features/Video/RatingPopup/RatingPopup.tsx
+++ b/src/features/Video/RatingPopup/RatingPopup.tsx
@@ -2,15 +2,21 @@ import { translate, userDataStore } from '@/App'
 import React, {
   Dispatch,
   SetStateAction,
+  useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react'
+import { createPortal } from 'react-dom'
 import './ratingPopup.scss'
 import { apiUrl } from '@/shared/config'
 import ourFetch from '@/shared/utils/ourFetch'
+import { getTabbableElements, hidePageBehind, trapTabKey } from './modalFocus'
 
 interface Props {
+  /** The popup mounts only while open, so focus and live regions behave predictably. */
+  isOpen: boolean
   audioDescriptionId: string
   comprehensionRating: number
   setComprehensionRating: Dispatch<SetStateAction<number>>
@@ -18,6 +24,8 @@ interface Props {
   setEnjoymentRating: Dispatch<SetStateAction<number>>
   comment: string
   setComment: Dispatch<SetStateAction<string>>
+  /** Server/session failures raised by the host page; rendered in the dialog's alert region. */
+  submitError?: string
   handleRatingSubmit: (
     comprehensionRating: number,
     enjoymentRating: number,
@@ -25,6 +33,10 @@ interface Props {
   ) => void
   handleRatingPopupClose: () => void
 }
+
+const COMPREHENSION_QUESTION =
+  'How well were you able to follow what was happening in the video?'
+const ENJOYMENT_QUESTION = 'How much did you enjoy the video?'
 
 const COMPREHENSION_CAPTIONS = [
   'Not at all',
@@ -42,6 +54,17 @@ const ENJOYMENT_CAPTIONS = [
   'A great deal',
 ]
 
+const ERROR_ID = 'rating-popup-error'
+const SUBTITLE_ID = 'rating-popup-subtitle'
+const DICTATION_HINT_ID = 'rating-dictation-hint'
+
+/** Option+S on a Mac reports as Alt+S, which is the aria-keyshortcuts spelling. */
+const DICTATION_SHORTCUT = 'Alt+S'
+
+/** "1 2 3 4 5" — the number keys that pick a score. */
+const scaleShortcuts = (count: number) =>
+  Array.from({ length: count }, (unused, index) => index + 1).join(' ')
+
 interface SpeechRecognitionLike {
   continuous: boolean
   interimResults: boolean
@@ -58,6 +81,7 @@ const SpeechRecognitionCtor =
   (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition // eslint-disable-line @typescript-eslint/no-explicit-any
 
 const RatingPopup = ({
+  isOpen,
   audioDescriptionId,
   comprehensionRating,
   setComprehensionRating,
@@ -65,16 +89,66 @@ const RatingPopup = ({
   setEnjoymentRating,
   comment,
   setComment,
+  submitError = '',
   handleRatingSubmit,
   handleRatingPopupClose,
 }: Props) => {
   const [isListening, setIsListening] = useState(false)
-  const rootRef = useRef<HTMLDivElement>(null)
+  const [validationError, setValidationError] = useState('')
+  const [prefillNotice, setPrefillNotice] = useState('')
+  const dialogRef = useRef<HTMLDivElement>(null)
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null)
   const baseCommentRef = useRef('')
   const finalTranscriptRef = useRef('')
 
+  // Rendering into body (rather than inside the page's <main>) keeps landmark
+  // navigation sane while the dialog is open and lets us hide the rest of body.
+  const portalTarget = useMemo(() => {
+    if (typeof document === 'undefined') {
+      return null
+    }
+    return document.createElement('div')
+  }, [])
+
   useEffect(() => {
+    if (!isOpen || !portalTarget) {
+      return undefined
+    }
+    document.body.appendChild(portalTarget)
+    const restorePage = hidePageBehind(portalTarget)
+    return () => {
+      restorePage()
+      portalTarget.remove()
+    }
+  }, [isOpen, portalTarget])
+
+  // Move focus into the dialog on open and hand it back to whatever opened it.
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined
+    }
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    dialogRef.current?.focus()
+    return () => {
+      if (previouslyFocused?.isConnected) {
+        previouslyFocused.focus()
+      }
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setValidationError('')
+      setPrefillNotice('')
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined
+    }
+    let cancelled = false
+
     const fetchUserRating = async () => {
       try {
         const userId = userDataStore.getState().userId
@@ -88,7 +162,7 @@ const RatingPopup = ({
           enjoymentRating: number | null
           comment: string
         } | null
-        if (!result) {
+        if (!result || cancelled) {
           return
         }
         if (result.rating !== null) {
@@ -100,13 +174,30 @@ const RatingPopup = ({
         if (result.comment) {
           setComment(result.comment)
         }
+        // Radios silently becoming selected is invisible to a screen reader, so
+        // say that the form was populated from a previous rating.
+        if (
+          result.rating !== null ||
+          result.enjoymentRating !== null ||
+          result.comment
+        ) {
+          setPrefillNotice(
+            translate(
+              'Your previous answers for this video have been filled in.',
+            ),
+          )
+        }
       } catch (error) {
         console.error('Error fetching user rating:', error)
       }
     }
 
     fetchUserRating()
+    return () => {
+      cancelled = true
+    }
   }, [
+    isOpen,
     audioDescriptionId,
     setComprehensionRating,
     setEnjoymentRating,
@@ -119,9 +210,9 @@ const RatingPopup = ({
     }
   }, [])
 
-  const stopDictation = () => {
+  const stopDictation = useCallback(() => {
     recognitionRef.current?.stop()
-  }
+  }, [])
 
   const toggleDictation = () => {
     if (isListening) {
@@ -158,19 +249,100 @@ const RatingPopup = ({
     setIsListening(true)
   }
 
-  const closePopup = () => {
+  const closePopup = useCallback(() => {
     stopDictation()
     handleRatingPopupClose()
-  }
+  }, [handleRatingPopupClose, stopDictation])
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Escape') {
+    if (event.key === 'Escape') {
+      closePopup()
       return
     }
-    if (rootRef.current?.style.display !== 'block') {
+    // event.code rather than event.key: Option+S emits "ß" on a Mac layout.
+    if (SpeechRecognitionCtor && event.altKey && event.code === 'KeyS') {
+      event.preventDefault()
+      toggleDictation()
       return
     }
-    closePopup()
+    if (dialogRef.current) {
+      trapTabKey(event, dialogRef.current)
+    }
+  }
+
+  const comprehensionMissing = comprehensionRating === 0
+  const enjoymentMissing = enjoymentRating === 0
+
+  const focusFirstUnanswered = () => {
+    const dialog = dialogRef.current
+    if (!dialog) {
+      return
+    }
+    const groupName = comprehensionMissing
+      ? 'comprehension-rating'
+      : 'enjoyment-rating'
+    const target = getTabbableElements(dialog).find(
+      (el) => el instanceof HTMLInputElement && el.name === groupName,
+    )
+    target?.focus()
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    stopDictation()
+
+    if (comprehensionMissing || enjoymentMissing) {
+      // Name the outstanding question rather than a generic failure, and put the
+      // message inside the dialog where aria-modal lets a screen reader reach it.
+      if (comprehensionMissing && enjoymentMissing) {
+        setValidationError(
+          translate('Please answer both questions before submitting.'),
+        )
+      } else {
+        setValidationError(
+          `${translate('Please answer this question:')} ${translate(
+            comprehensionMissing ? COMPREHENSION_QUESTION : ENJOYMENT_QUESTION,
+          )}`,
+        )
+      }
+      focusFirstUnanswered()
+      return
+    }
+
+    setValidationError('')
+    handleRatingSubmit(comprehensionRating, enjoymentRating, comment)
+  }
+
+  const errorMessage = validationError || submitError
+
+  const selectScore = (
+    name: string,
+    score: number,
+    onSelect: (score: number) => void,
+  ) => {
+    setValidationError('')
+    onSelect(score)
+    // Move the cursor onto the chosen radio so the selection is announced.
+    const radio = document.getElementById(`${name}-${score}`)
+    radio?.focus()
+  }
+
+  /** Number keys pick a score directly, so the scale is one keystroke deep. */
+  const handleScaleKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+    name: string,
+    captionCount: number,
+    onSelect: (score: number) => void,
+  ) => {
+    if (event.altKey || event.ctrlKey || event.metaKey) {
+      return
+    }
+    const score = Number(event.key)
+    if (!Number.isInteger(score) || score < 1 || score > captionCount) {
+      return
+    }
+    event.preventDefault()
+    selectScore(name, score, onSelect)
   }
 
   const renderScale = (
@@ -178,6 +350,7 @@ const RatingPopup = ({
     captions: string[],
     value: number,
     onSelect: (score: number) => void,
+    isInvalid: boolean,
   ) =>
     captions.map((caption, index) => {
       const score = index + 1
@@ -189,8 +362,12 @@ const RatingPopup = ({
             name={name}
             value={score}
             checked={value === score}
-            onChange={() => onSelect(score)}
+            onChange={() => {
+              setValidationError('')
+              onSelect(score)
+            }}
             aria-describedby={`${name}-${score}-caption`}
+            aria-invalid={isInvalid || undefined}
           />
           <label htmlFor={`${name}-${score}`}>
             <span className="scale-number">{score}</span>
@@ -202,67 +379,100 @@ const RatingPopup = ({
       )
     })
 
-  return (
-    <div
-      id="rating-popup"
-      tabIndex={-1}
-      ref={rootRef}
-      onKeyDown={handleKeyDown}
-    >
+  const renderQuestion = (
+    name: string,
+    question: string,
+    captions: string[],
+    value: number,
+    onSelect: (score: number) => void,
+  ) => {
+    // A radiogroup rather than a fieldset: aria-required is not allowed on an
+    // individual radio, and nesting a radiogroup inside a fieldset would make
+    // VoiceOver read the question twice.
+    const labelId = `${name}-label`
+    const hintId = `${name}-hint`
+    const isInvalid = Boolean(validationError) && value === 0
+    return (
+      <div
+        className="rating-question"
+        role="radiogroup"
+        aria-labelledby={labelId}
+        aria-required="true"
+        aria-invalid={isInvalid || undefined}
+        // Group-level, so it is read once on entering the scale rather than
+        // again on every arrow key, which moves focus between the radios.
+        aria-describedby={isInvalid ? `${hintId} ${ERROR_ID}` : hintId}
+        aria-keyshortcuts={scaleShortcuts(captions.length)}
+        onKeyDown={(event) =>
+          handleScaleKeyDown(event, name, captions.length, onSelect)
+        }
+      >
+        <p className="rating-question-label" id={labelId}>
+          {translate(question)}
+        </p>
+        {/* Enumerates the scale so the options are known without arrowing
+            through all five, and states the number-key shortcut. */}
+        <p className="visually-hidden" id={hintId}>
+          {`${translate('Press a number to answer')}, ${captions
+            .map((caption, index) => `${index + 1} ${translate(caption)}`)
+            .join(', ')}`}
+        </p>
+        <div className="scale">
+          {renderScale(name, captions, value, onSelect, isInvalid)}
+        </div>
+      </div>
+    )
+  }
+
+  if (!isOpen || !portalTarget) {
+    return null
+  }
+
+  return createPortal(
+    <div id="rating-popup" onKeyDown={handleKeyDown}>
       <div
         id="rating-popup-contents"
+        ref={dialogRef}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-labelledby="rating-popup-title"
+        aria-describedby={SUBTITLE_ID}
       >
-        <a
+        <button
+          type="button"
           className="close-window"
-          aria-label="close window"
-          href="#"
-          onClick={(event) => {
-            event.preventDefault()
-            closePopup()
-          }}
+          aria-label={translate('Close window')}
+          onClick={closePopup}
         >
-          <i className="fa fa-window-close" />
-        </a>
+          <i className="fa fa-window-close" aria-hidden="true" />
+        </button>
         <h2 id="rating-popup-title">{translate('Two quick questions')}</h2>
-        <p className="rating-subtitle">
+        <p className="rating-subtitle" id={SUBTITLE_ID}>
           {translate('About the video you just watched.')}
         </p>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault()
-            stopDictation()
-            handleRatingSubmit(comprehensionRating, enjoymentRating, comment)
-          }}
-        >
-          <fieldset className="rating-question">
-            <legend>
-              {translate(
-                'How well were you able to follow what was happening in the video?',
-              )}
-            </legend>
-            <div className="scale">
-              {renderScale(
-                'comprehension-rating',
-                COMPREHENSION_CAPTIONS,
-                comprehensionRating,
-                setComprehensionRating,
-              )}
-            </div>
-          </fieldset>
-          <fieldset className="rating-question">
-            <legend>{translate('How much did you enjoy the video?')}</legend>
-            <div className="scale">
-              {renderScale(
-                'enjoyment-rating',
-                ENJOYMENT_CAPTIONS,
-                enjoymentRating,
-                setEnjoymentRating,
-              )}
-            </div>
-          </fieldset>
+        {/* Always mounted so the region is registered before it gains text. */}
+        <div className="visually-hidden" role="status">
+          {prefillNotice}
+        </div>
+        <div className="rating-error" id={ERROR_ID} role="alert">
+          {errorMessage}
+        </div>
+        <form onSubmit={handleSubmit} noValidate>
+          {renderQuestion(
+            'comprehension-rating',
+            COMPREHENSION_QUESTION,
+            COMPREHENSION_CAPTIONS,
+            comprehensionRating,
+            setComprehensionRating,
+          )}
+          {renderQuestion(
+            'enjoyment-rating',
+            ENJOYMENT_QUESTION,
+            ENJOYMENT_CAPTIONS,
+            enjoymentRating,
+            setEnjoymentRating,
+          )}
           <div className="comment-block">
             <label htmlFor="rating-comment">
               {translate("Anything else you'd like us to know?")}{' '}
@@ -277,19 +487,40 @@ const RatingPopup = ({
                   'Optional — any other thoughts about the video or its description.',
                 )}
                 onChange={(event) => setComment(event.target.value)}
+                aria-describedby={
+                  SpeechRecognitionCtor ? DICTATION_HINT_ID : undefined
+                }
+                aria-keyshortcuts={
+                  SpeechRecognitionCtor ? DICTATION_SHORTCUT : undefined
+                }
               />
               {SpeechRecognitionCtor && (
-                <button
-                  type="button"
-                  className={`mic-button ${isListening ? 'listening' : ''}`}
-                  onClick={toggleDictation}
-                  aria-pressed={isListening}
-                  aria-label={translate(
-                    isListening ? 'Stop dictation' : 'Dictate your answer',
-                  )}
-                >
-                  <i className="fa fa-microphone" />
-                </button>
+                <>
+                  {/* Announced on reaching the comment box, so the shortcut is
+                      known before the mic button is tabbed to. */}
+                  <span className="visually-hidden" id={DICTATION_HINT_ID}>
+                    {translate(
+                      'Press Option plus S to start or stop voice dictation',
+                    )}
+                  </span>
+                  <button
+                    type="button"
+                    className={`mic-button ${isListening ? 'listening' : ''}`}
+                    onClick={toggleDictation}
+                    aria-pressed={isListening}
+                    aria-label={translate(
+                      isListening
+                        ? 'Stop dictating note, press Option plus S'
+                        : 'Dictate note with microphone, press Option plus S',
+                    )}
+                    title={`${translate('Speak your note')}, ${translate(
+                      'Option plus S',
+                    )}`}
+                    aria-keyshortcuts={DICTATION_SHORTCUT}
+                  >
+                    <i className="fa fa-microphone" aria-hidden="true" />
+                  </button>
+                </>
               )}
               <span className="dictation-status" role="status">
                 {isListening ? translate('Listening…') : ''}
@@ -297,16 +528,25 @@ const RatingPopup = ({
             </div>
           </div>
           <div className="rating-footer">
-            <button type="button" className="back-button" onClick={closePopup}>
+            {/* The keycap and arrow stay in the accessible names to match the
+                agreed VoiceOver script ("Back Esc", "Submit & finish "); 
+                aria-hidden on them would drop both. */}
+            <button
+              type="button"
+              className="back-button"
+              onClick={closePopup}
+              aria-keyshortcuts="Escape"
+            >
               {translate('Back')} <kbd className="keycap">Esc</kbd>
             </button>
             <button type="submit" className="submit-button">
-              {translate('Submit & finish')} →
+              {translate('Submit & finish')} <span>&rarr;</span>
             </button>
           </div>
         </form>
       </div>
-    </div>
+    </div>,
+    portalTarget,
   )
 }
 

--- a/src/features/Video/RatingPopup/RatingPopup.tsx
+++ b/src/features/Video/RatingPopup/RatingPopup.tsx
@@ -1,26 +1,78 @@
 import { translate, userDataStore } from '@/App'
-import Button from '@/shared/components/Button/Button'
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import './ratingPopup.scss'
 import { apiUrl } from '@/shared/config'
 import ourFetch from '@/shared/utils/ourFetch'
 
 interface Props {
   audioDescriptionId: string
-  rating: number
-  setRating: Dispatch<SetStateAction<number>>
-  handleRatingSubmit: (rating: number) => void
+  comprehensionRating: number
+  setComprehensionRating: Dispatch<SetStateAction<number>>
+  enjoymentRating: number
+  setEnjoymentRating: Dispatch<SetStateAction<number>>
+  comment: string
+  setComment: Dispatch<SetStateAction<string>>
+  handleRatingSubmit: (
+    comprehensionRating: number,
+    enjoymentRating: number,
+    comment: string,
+  ) => void
   handleRatingPopupClose: () => void
 }
 
+const COMPREHENSION_CAPTIONS = [
+  'Not at all',
+  'A little',
+  'Somewhat',
+  'Mostly',
+  'Completely',
+]
+
+const ENJOYMENT_CAPTIONS = [
+  'Not at all',
+  'A little',
+  'Somewhat',
+  'Quite a bit',
+  'A great deal',
+]
+
+interface SpeechRecognitionLike {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  start: () => void
+  stop: () => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onresult: ((event: any) => void) | null
+  onerror: (() => void) | null
+  onend: (() => void) | null
+}
+
+const SpeechRecognitionCtor =
+  (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition // eslint-disable-line @typescript-eslint/no-explicit-any
+
 const RatingPopup = ({
   audioDescriptionId,
-  rating,
-  setRating,
+  comprehensionRating,
+  setComprehensionRating,
+  enjoymentRating,
+  setEnjoymentRating,
+  comment,
+  setComment,
   handleRatingSubmit,
   handleRatingPopupClose,
 }: Props) => {
-  const [userRating, setUserRating] = useState<number | null>(null)
+  const [isListening, setIsListening] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null)
+  const baseCommentRef = useRef('')
+  const finalTranscriptRef = useRef('')
 
   useEffect(() => {
     const fetchUserRating = async () => {
@@ -31,9 +83,22 @@ const RatingPopup = ({
         }
         const url = `${apiUrl}/audio-descriptions/ratings/user/${audioDescriptionId}?userId=${userId}`
         const response = await ourFetch(url)
-        setUserRating(response.result)
-        if (response.result !== null) {
-          setRating(response.result)
+        const result = response.result as {
+          rating: number | null
+          enjoymentRating: number | null
+          comment: string
+        } | null
+        if (!result) {
+          return
+        }
+        if (result.rating !== null) {
+          setComprehensionRating(result.rating)
+        }
+        if (result.enjoymentRating !== null) {
+          setEnjoymentRating(result.enjoymentRating)
+        }
+        if (result.comment) {
+          setComment(result.comment)
         }
       } catch (error) {
         console.error('Error fetching user rating:', error)
@@ -41,102 +106,204 @@ const RatingPopup = ({
     }
 
     fetchUserRating()
-  }, [audioDescriptionId, setRating])
+  }, [
+    audioDescriptionId,
+    setComprehensionRating,
+    setEnjoymentRating,
+    setComment,
+  ])
 
-  const renderStars = () => {
-    const stars = []
-    for (let i = 5; i >= 1; i--) {
-      stars.push(
-        <button
-          key={i}
-          onClick={() => handleRatingSubmit(i)}
-          className={`star ${i <= (rating || userRating || 0) ? 'filled' : ''}`}
-          tabIndex={-1}
-        >
-          ★
-        </button>,
-      )
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.stop()
     }
-    return stars
+  }, [])
+
+  const stopDictation = () => {
+    recognitionRef.current?.stop()
   }
 
-  return (
-    <div id="rating-popup" tabIndex={-1}>
-      <div id="rating-popup-contents">
-        <a aria-label="close window" href="#" onClick={handleRatingPopupClose}>
-          <i className="fa fa-window-close" />
-        </a>
-        <h2>{translate('Rate description')}</h2>
-        <p>
-          {translate(
-            'Please rate this description with 1 star being unusable and 5 stars being perfect',
-          )}
-        </p>
-        <div className="rating" aria-hidden="true">
-          {renderStars()}
+  const toggleDictation = () => {
+    if (isListening) {
+      stopDictation()
+      return
+    }
+
+    const recognition: SpeechRecognitionLike = new SpeechRecognitionCtor()
+    recognition.continuous = true
+    recognition.interimResults = true
+    recognition.lang = navigator.language || 'en-US'
+
+    baseCommentRef.current = comment ? `${comment.trimEnd()} ` : ''
+    finalTranscriptRef.current = ''
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recognition.onresult = (event: any) => {
+      let interim = ''
+      for (let i = event.resultIndex; i < event.results.length; i += 1) {
+        const transcript = event.results[i][0].transcript
+        if (event.results[i].isFinal) {
+          finalTranscriptRef.current += transcript
+        } else {
+          interim += transcript
+        }
+      }
+      setComment(baseCommentRef.current + finalTranscriptRef.current + interim)
+    }
+    recognition.onerror = () => setIsListening(false)
+    recognition.onend = () => setIsListening(false)
+
+    recognitionRef.current = recognition
+    recognition.start()
+    setIsListening(true)
+  }
+
+  const closePopup = () => {
+    stopDictation()
+    handleRatingPopupClose()
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Escape') {
+      return
+    }
+    if (rootRef.current?.style.display !== 'block') {
+      return
+    }
+    closePopup()
+  }
+
+  const renderScale = (
+    name: string,
+    captions: string[],
+    value: number,
+    onSelect: (score: number) => void,
+  ) =>
+    captions.map((caption, index) => {
+      const score = index + 1
+      return (
+        <div className="scale-option" key={score}>
+          <input
+            type="radio"
+            id={`${name}-${score}`}
+            name={name}
+            value={score}
+            checked={value === score}
+            onChange={() => onSelect(score)}
+            aria-describedby={`${name}-${score}-caption`}
+          />
+          <label htmlFor={`${name}-${score}`}>
+            <span className="scale-number">{score}</span>
+          </label>
+          <span className="scale-caption" id={`${name}-${score}-caption`}>
+            {translate(caption)}
+          </span>
         </div>
-        <form
-          className="skip"
-          onSubmit={(event) => {
+      )
+    })
+
+  return (
+    <div
+      id="rating-popup"
+      tabIndex={-1}
+      ref={rootRef}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        id="rating-popup-contents"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rating-popup-title"
+      >
+        <a
+          className="close-window"
+          aria-label="close window"
+          href="#"
+          onClick={(event) => {
             event.preventDefault()
-            handleRatingSubmit(rating)
+            closePopup()
           }}
         >
-          <input
-            id="rating-1"
-            type="radio"
-            name="rating"
-            value="1"
-            onChange={() => setRating(1)}
-            checked={rating === 1}
-          />
-          <label htmlFor="rating-1"> 1 star</label>
-          <br />
-          <input
-            id="rating-2"
-            type="radio"
-            name="rating"
-            value="2"
-            onChange={() => setRating(2)}
-            checked={rating === 2}
-          />
-          <label htmlFor="rating-2"> 2 stars</label>
-          <br />
-          <input
-            id="rating-3"
-            type="radio"
-            name="rating"
-            value="3"
-            onChange={() => setRating(3)}
-            checked={rating === 3}
-          />
-          <label htmlFor="rating-3"> 3 stars</label>
-          <br />
-          <input
-            id="rating-4"
-            type="radio"
-            name="rating"
-            value="4"
-            onChange={() => setRating(4)}
-            checked={rating === 4}
-          />
-          <label htmlFor="rating-4"> 4 stars</label>
-          <br />
-          <input
-            id="rating-5"
-            type="radio"
-            name="rating"
-            value="5"
-            onChange={() => setRating(5)}
-            checked={rating === 5}
-          />
-          <label htmlFor="rating-5"> 5 stars</label>
-          <br />
-          <Button
-            ariaLabel="Submit rating"
-            text="Submit rating"
-            color="w3-indigo w3-margin-top w3-center"
-          />
+          <i className="fa fa-window-close" />
+        </a>
+        <h2 id="rating-popup-title">{translate('Two quick questions')}</h2>
+        <p className="rating-subtitle">
+          {translate('About the video you just watched.')}
+        </p>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            stopDictation()
+            handleRatingSubmit(comprehensionRating, enjoymentRating, comment)
+          }}
+        >
+          <fieldset className="rating-question">
+            <legend>
+              {translate(
+                'How well were you able to follow what was happening in the video?',
+              )}
+            </legend>
+            <div className="scale">
+              {renderScale(
+                'comprehension-rating',
+                COMPREHENSION_CAPTIONS,
+                comprehensionRating,
+                setComprehensionRating,
+              )}
+            </div>
+          </fieldset>
+          <fieldset className="rating-question">
+            <legend>{translate('How much did you enjoy the video?')}</legend>
+            <div className="scale">
+              {renderScale(
+                'enjoyment-rating',
+                ENJOYMENT_CAPTIONS,
+                enjoymentRating,
+                setEnjoymentRating,
+              )}
+            </div>
+          </fieldset>
+          <div className="comment-block">
+            <label htmlFor="rating-comment">
+              {translate("Anything else you'd like us to know?")}{' '}
+              <span className="optional-tag">({translate('optional')})</span>
+            </label>
+            <div className="comment-wrap">
+              <textarea
+                id="rating-comment"
+                rows={3}
+                value={comment}
+                placeholder={translate(
+                  'Optional — any other thoughts about the video or its description.',
+                )}
+                onChange={(event) => setComment(event.target.value)}
+              />
+              {SpeechRecognitionCtor && (
+                <button
+                  type="button"
+                  className={`mic-button ${isListening ? 'listening' : ''}`}
+                  onClick={toggleDictation}
+                  aria-pressed={isListening}
+                  aria-label={translate(
+                    isListening ? 'Stop dictation' : 'Dictate your answer',
+                  )}
+                >
+                  <i className="fa fa-microphone" />
+                </button>
+              )}
+              <span className="dictation-status" role="status">
+                {isListening ? translate('Listening…') : ''}
+              </span>
+            </div>
+          </div>
+          <div className="rating-footer">
+            <button type="button" className="back-button" onClick={closePopup}>
+              {translate('Back')} <kbd className="keycap">Esc</kbd>
+            </button>
+            <button type="submit" className="submit-button">
+              {translate('Submit & finish')} →
+            </button>
+          </div>
         </form>
       </div>
     </div>

--- a/src/features/Video/RatingPopup/modalFocus.ts
+++ b/src/features/Video/RatingPopup/modalFocus.ts
@@ -1,0 +1,102 @@
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+/**
+ * The elements inside `root` that Tab will actually visit, in document order.
+ *
+ * Radio groups need special handling: only one radio per group is in the tab
+ * sequence (the checked one, or the first when nothing is checked yet), so
+ * treating every radio as tabbable would compute the wrong ring boundaries.
+ */
+export const getTabbableElements = (root: HTMLElement): HTMLElement[] =>
+  Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => {
+      if (el.getAttribute('aria-hidden') === 'true') {
+        return false
+      }
+      if (el instanceof HTMLInputElement && el.type === 'radio') {
+        const group = Array.from(
+          root.querySelectorAll<HTMLInputElement>(
+            `input[type="radio"][name="${el.name}"]`,
+          ),
+        )
+        const checked = group.find((radio) => radio.checked)
+        return el === (checked ?? group[0])
+      }
+      return true
+    },
+  )
+
+/**
+ * Keeps Tab inside `container`. `aria-modal` alone does not do this — it only
+ * constrains a screen reader's own cursor, not the browser's focus order.
+ */
+export const trapTabKey = (
+  event: KeyboardEvent | React.KeyboardEvent,
+  container: HTMLElement,
+) => {
+  if (event.key !== 'Tab') {
+    return
+  }
+
+  const tabbable = getTabbableElements(container)
+  if (tabbable.length === 0) {
+    event.preventDefault()
+    container.focus()
+    return
+  }
+
+  const first = tabbable[0]
+  const last = tabbable[tabbable.length - 1]
+  const active = document.activeElement
+
+  if (event.shiftKey) {
+    // Shift+Tab from the first control (or from the container itself, which is
+    // where focus starts) would otherwise land on the page behind.
+    if (active === first || active === container) {
+      event.preventDefault()
+      last.focus()
+    }
+    return
+  }
+
+  if (active === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+/**
+ * Hides everything outside `except` from assistive tech and from the tab order
+ * for as long as the dialog is open. Returns the undo function.
+ *
+ * `inert` covers focus and pointer events in modern Safari/Chrome; `aria-hidden`
+ * is the fallback that older VoiceOver builds honour. Elements that were already
+ * hidden are left alone so we never un-hide something another component owns.
+ */
+export const hidePageBehind = (except: HTMLElement) => {
+  const changed: HTMLElement[] = []
+
+  Array.from(document.body.children).forEach((child) => {
+    const el = child as HTMLElement
+    if (el === except || el.getAttribute('aria-hidden') === 'true') {
+      return
+    }
+    el.setAttribute('aria-hidden', 'true')
+    el.setAttribute('inert', '')
+    changed.push(el)
+  })
+
+  return () => {
+    changed.forEach((el) => {
+      el.removeAttribute('aria-hidden')
+      el.removeAttribute('inert')
+    })
+  }
+}

--- a/src/features/Video/RatingPopup/ratingPopup.scss
+++ b/src/features/Video/RatingPopup/ratingPopup.scss
@@ -11,66 +11,283 @@
   #rating-popup-contents {
     position: fixed;
     z-index: 9999;
-    width: 350px;
-    height: 200px;
-    top: calc(50% - 100px);
-    left: calc(50% - 175px);
-    border: 1px solid #3f51b5;
-    background-color: white;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(680px, 92vw);
+    height: auto;
+    max-height: 90vh;
+    overflow-y: auto;
+    border-radius: 12px;
+    background-color: #fff;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    padding: 24px;
+    text-align: left;
 
-    a {
-      color: #fff;
-    }
-
-    i {
+    .close-window {
       position: absolute;
-      top: 4px;
-      right: 4px;
-      font-size: 20px;
+      top: 12px;
+      right: 12px;
+      color: #666;
+      font-size: 18px;
       cursor: pointer;
+
+      &:hover {
+        color: #1a1a3d;
+      }
     }
 
     h2 {
-      margin: 0;
-      padding: 8px 0;
-      background-color: #3f51b5;
-      text-align: center;
+      margin: 0 0 4px;
+      padding: 0;
+      font-size: 20px;
+      color: #1a1a3d;
     }
 
-    p {
-      margin: 16px;
+    .rating-subtitle {
+      margin: 0 0 20px;
       color: grey;
       font-size: 14px;
     }
 
-    .rating {
-      width: 100%;
-      direction: rtl;
-      text-align: center;
-      font-size: 24px;
+    .rating-question {
+      border: 0;
+      margin: 0 0 20px;
+      padding: 0;
+
+      legend {
+        padding: 0;
+        margin-bottom: 10px;
+        font-weight: 600;
+        font-size: .98rem;
+        color: #1f2042;
+      }
     }
 
-    .rating > button {
-      color: grey;
-      display: inline-block;
+    .scale {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 8px;
+    }
+
+    .scale-option {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 5px;
+
+      input {
+        position: absolute;
+        opacity: 0;
+        width: 1px;
+        height: 1px;
+        outline: none;
+        -webkit-appearance: none;
+        appearance: none;
+      }
+
+      label {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        border: 1px solid #d6d8e7;
+        border-radius: 8px;
+        padding: 10px 4px;
+        cursor: pointer;
+        box-sizing: border-box;
+        transition:
+          background-color 0.15s,
+          border-color 0.15s,
+          color 0.15s;
+
+        &:hover {
+          border-color: #212529;
+        }
+      }
+
+      .scale-number {
+        font-size: .98rem;
+        font-weight: 600;
+        color: #1a1a3d;
+      }
+
+      .scale-caption {
+        font-size: 11px;
+        color: grey;
+        text-align: center;
+      }
+
+      input:checked + label {
+        background-color: #212529;
+        border-color: #212529;
+
+        .scale-number {
+          color: #fff;
+        }
+      }
+
+      label:focus,
+      label:focus-visible {
+        outline: none;
+      }
+
+      input:focus + label {
+        outline: 2px solid #212529;
+        outline-offset: 2px;
+      }
+    }
+
+    .comment-block {
+      margin-bottom: 20px;
+
+      label {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 14px;
+        font-weight: 600;
+        color: #1a1a3d;
+      }
+
+      .optional-tag {
+        font-weight: 400;
+        color: grey;
+      }
+    }
+
+    .comment-wrap {
       position: relative;
-      padding: 0 1px;
-      font-size: 24px;
-      width: 1.1em;
-      background-color: transparent;
-      border: none;
-      outline: none;
-      cursor: pointer;
-      transition: color 0.2s;
 
-      &.filled {
-        color: gold;
+      textarea {
+        width: 100%;
+        min-height: 88px;
+        border: 1px solid #d6d8e7;
+        border-radius: 8px;
+        padding: 10px 44px 10px 12px;
+        font-family: inherit;
+        font-size: 14px;
+        resize: vertical;
+        box-sizing: border-box;
+
+        &:focus {
+          outline: none;
+          border-color: #212529;
+        }
       }
 
-      &:hover,
-      &:hover ~ button {
-        color: gold;
+      .mic-button {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        border: none;
+        background-color: transparent;
+        color: #212529;
+        cursor: pointer;
+
+        &:hover {
+          background-color: #e4e6fa;
+        }
+
+        &.listening {
+          color: #c62828;
+          animation: rating-mic-pulse 1.2s infinite;
+        }
       }
+
+      .dictation-status {
+        position: absolute;
+        bottom: -18px;
+        left: 0;
+        font-size: 12px;
+        color: #212529;
+      }
+    }
+
+    .rating-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-top: 8px;
+      flex-wrap: wrap;
+
+      .back-button {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        background-color: #fff;
+        border: 1px solid #d6d8e7;
+        border-radius: 8px;
+        padding: 10px 18px;
+        font-weight: 600;
+        cursor: pointer;
+
+        &:hover {
+          border-color: #3e4156;
+        }
+      }
+
+      .keycap {
+        font-size: 11px;
+        font-family: monospace;
+        border: 1px solid #d6d8e7;
+        border-bottom-width: 2px;
+        border-radius: 4px;
+        padding: 1px 6px;
+        color: grey;
+      }
+
+      .submit-button {
+        background-color: #212529;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        padding: 10px 20px;
+        font-weight: 600;
+        cursor: pointer;
+
+        &:hover {
+          background-color: #3e4156;
+        }
+
+        &:focus-visible {
+          outline: 2px solid #1a1a3d;
+          outline-offset: 2px;
+        }
+      }
+    }
+  }
+}
+
+@keyframes rating-mic-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #rating-popup .mic-button.listening {
+    animation: none;
+  }
+}
+
+@media (max-width: 480px) {
+  #rating-popup #rating-popup-contents {
+    padding: 16px;
+
+    .scale {
+      gap: 4px;
+    }
+
+    .scale-caption {
+      font-size: 10px;
     }
   }
 }

--- a/src/features/Video/RatingPopup/ratingPopup.scss
+++ b/src/features/Video/RatingPopup/ratingPopup.scss
@@ -1,5 +1,6 @@
 #rating-popup {
-  display: none;
+  // Mounted only while open (see RatingPopup.tsx), so no display toggling here.
+  display: block;
   position: fixed;
   top: 0;
   left: 0;
@@ -28,12 +29,21 @@
       position: absolute;
       top: 12px;
       right: 12px;
-      color: #666;
+      padding: 4px;
+      border: none;
+      background: none;
+      line-height: 1;
+      color: #1c3557;
       font-size: 18px;
       cursor: pointer;
 
       &:hover {
-        color: #1a1a3d;
+        opacity: 0.92;
+      }
+
+      &:focus-visible {
+        outline: 2px solid #1a1a3d;
+        outline-offset: 2px;
       }
     }
 
@@ -50,17 +60,38 @@
       font-size: 14px;
     }
 
-    .rating-question {
-      border: 0;
-      margin: 0 0 20px;
-      padding: 0;
+    // Empty until validation fails, but always rendered so role="alert" is
+    // registered before it gains text. Collapses to zero height when empty
+    // without display:none, which can suppress the announcement.
+    .rating-error {
+      color: #b3261e;
+      font-size: 14px;
+      font-weight: 600;
 
-      legend {
+      &:not(:empty) {
+        margin: 0 0 16px;
+        padding: 10px 12px;
+        border: 1px solid #b3261e;
+        border-radius: 8px;
+        background-color: #fdecea;
+      }
+    }
+
+    .rating-question {
+      margin: 0 0 20px;
+
+      .rating-question-label {
+        margin: 0 0 10px;
         padding: 0;
-        margin-bottom: 10px;
         font-weight: 600;
-        font-size: .98rem;
+        font-size: 0.98rem;
         color: #1f2042;
+      }
+
+      // Pair the alert text with a visible cue so the invalid group is not
+      // identified by the message alone.
+      &[aria-invalid='true'] .scale-option label {
+        border-color: #b3261e;
       }
     }
 
@@ -96,18 +127,15 @@
         padding: 10px 4px;
         cursor: pointer;
         box-sizing: border-box;
-        transition:
-          background-color 0.15s,
-          border-color 0.15s,
-          color 0.15s;
+        transition: background-color 0.15s, border-color 0.15s, color 0.15s;
 
         &:hover {
-          border-color: #212529;
+          border-color: #1c3557;
         }
       }
 
       .scale-number {
-        font-size: .98rem;
+        font-size: 0.98rem;
         font-weight: 600;
         color: #1a1a3d;
       }
@@ -119,8 +147,8 @@
       }
 
       input:checked + label {
-        background-color: #212529;
-        border-color: #212529;
+        background-color: #1c3557;
+        border-color: #1c3557;
 
         .scale-number {
           color: #fff;
@@ -133,7 +161,7 @@
       }
 
       input:focus + label {
-        outline: 2px solid #212529;
+        outline: 2px solid #1c3557;
         outline-offset: 2px;
       }
     }
@@ -171,7 +199,7 @@
 
         &:focus {
           outline: none;
-          border-color: #212529;
+          border-color: #1c3557;
         }
       }
 
@@ -184,7 +212,7 @@
         border-radius: 50%;
         border: none;
         background-color: transparent;
-        color: #212529;
+        color: #1c3557;
         cursor: pointer;
 
         &:hover {
@@ -202,7 +230,7 @@
         bottom: -18px;
         left: 0;
         font-size: 12px;
-        color: #212529;
+        color: #1c3557;
       }
     }
 
@@ -237,11 +265,12 @@
         border-bottom-width: 2px;
         border-radius: 4px;
         padding: 1px 6px;
+        background-color: #f5f5f5;
         color: grey;
       }
 
       .submit-button {
-        background-color: #212529;
+        background-color: #1c3557;
         color: #fff;
         border: none;
         border-radius: 8px;
@@ -250,11 +279,11 @@
         cursor: pointer;
 
         &:hover {
-          background-color: #3e4156;
+          opacity: .92;
         }
 
         &:focus-visible {
-          outline: 2px solid #1a1a3d;
+          outline: 2px solid #1c3557;
           outline-offset: 2px;
         }
       }

--- a/src/features/Video/RatingPopup/useRatingPopup.ts
+++ b/src/features/Video/RatingPopup/useRatingPopup.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * How long the confirmation stays on screen. The old implementation used 1s,
+ * which cut VoiceOver off mid-sentence.
+ */
+const SUCCESS_MESSAGE_TIMEOUT_MS = 6000
+
+/**
+ * Owns the open/closed and post-submit-confirmation state for the rating popup.
+ *
+ * Video.tsx and Video_v2.tsx both host the popup and previously each carried
+ * their own copy of this logic (toggling `display` on `#rating-popup` by id and
+ * focusing a transient success div). Keeping it here means the accessibility
+ * behaviour — mount/unmount instead of display toggling, and a confirmation
+ * that survives long enough to be announced — only has one implementation.
+ */
+export const useRatingPopup = () => {
+  const [isRatingPopupOpen, setIsRatingPopupOpen] = useState(false)
+  const [ratingSubmitError, setRatingSubmitError] = useState('')
+  const [ratingSuccessMessage, setRatingSuccessMessage] = useState('')
+
+  const openRatingPopup = useCallback(() => {
+    setRatingSubmitError('')
+    setRatingSuccessMessage('')
+    setIsRatingPopupOpen(true)
+  }, [])
+
+  const closeRatingPopup = useCallback(() => {
+    setRatingSubmitError('')
+    setIsRatingPopupOpen(false)
+  }, [])
+
+  /** Close after a successful save and hand the popup's own message to the page live region. */
+  const completeRatingPopup = useCallback((message: string) => {
+    setRatingSubmitError('')
+    setIsRatingPopupOpen(false)
+    setRatingSuccessMessage(message)
+  }, [])
+
+  // Clearing the text afterwards does not retract what was already announced,
+  // so the visual confirmation can be dismissed without affecting the live region.
+  useEffect(() => {
+    if (!ratingSuccessMessage) {
+      return undefined
+    }
+    const timeout = window.setTimeout(
+      () => setRatingSuccessMessage(''),
+      SUCCESS_MESSAGE_TIMEOUT_MS,
+    )
+    return () => window.clearTimeout(timeout)
+  }, [ratingSuccessMessage])
+
+  return {
+    isRatingPopupOpen,
+    openRatingPopup,
+    closeRatingPopup,
+    completeRatingPopup,
+    ratingSubmitError,
+    setRatingSubmitError,
+    ratingSuccessMessage,
+  }
+}

--- a/src/pages/Video/Video.tsx
+++ b/src/pages/Video/Video.tsx
@@ -33,6 +33,7 @@ import { convertLikesToCardFormat } from '@/shared/utils/convertLikesToCardForma
 import { convertISO8601ToDate } from '@/shared/utils/convertISO8601ToDate'
 import DescriberCard from '@/features/Video/DescriberCard/DescriberCard'
 import RatingPopup from '@/features/Video/RatingPopup/RatingPopup'
+import { useRatingPopup } from '@/features/Video/RatingPopup/useRatingPopup'
 // Optional feedback UI disabled — see commented-out usages below. Data field (`feedback`) is still sent/stored.
 // import FeedbackPopup from '@/features/Video/FeedbackPopup/FeedbackPopup'
 import RatingsInfoCard from '@/features/Video/RatingsInfoCard/RatingsInfoCard'
@@ -92,6 +93,15 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
   const [rating, setRating] = useState<number>(0)
   const [enjoymentRating, setEnjoymentRating] = useState<number>(0)
   const [ratingComment, setRatingComment] = useState<string>('')
+  const {
+    isRatingPopupOpen,
+    openRatingPopup,
+    closeRatingPopup,
+    completeRatingPopup,
+    ratingSubmitError,
+    setRatingSubmitError,
+    ratingSuccessMessage,
+  } = useRatingPopup()
   // const codes = iso6391.getAllCodes()
 
   const languages = [
@@ -994,10 +1004,12 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
     enjoymentScore: number,
     ratingCommentText: string,
   ) => {
-    if (comprehensionRating === 0 || enjoymentScore === 0)
-      toast.error(translate('Please answer both questions'))
-    else if (!userDataStore.getState().isSignedIn) {
-      toast.error(translate('You have to be logged in in order to vote'))
+    // The popup validates that both questions are answered and reports it in its
+    // own alert region, so this only has to handle session/server failures.
+    if (!userDataStore.getState().isSignedIn) {
+      setRatingSubmitError(
+        translate('You have to be logged in in order to vote'),
+      )
     } else {
       const url = `${apiUrl}/audio-descriptions/ratings/addOne/${selectedADId}`
       ourFetch(url, true, {
@@ -1014,18 +1026,10 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
         }),
       })
         .then((res) => {
-          // if (rating === 5) {
-          // toast.error(`You have successfully given this description a rating of ${rating}`);
-          const ratingPopup = document.getElementById('rating-popup')
-          const ratingSuccess = document.getElementById('rating-success')
-          if (ratingPopup) {
-            ratingPopup.style.display = 'none'
-          }
-          if (ratingSuccess) {
-            ratingSuccess.style.display = 'block'
-            ratingSuccess.focus()
-            setTimeout(() => (ratingSuccess.style.display = 'none'), 1000)
-          }
+          // Closes the popup (which hands focus back to the trigger) and puts the
+          // confirmation in a live region instead of focusing a div that is then
+          // torn down a second later.
+          completeRatingPopup(translate('Thanks for rating this description!'))
 
           /* start of email */
           sendOptInEmail(2, comprehensionRating, [])
@@ -1035,30 +1039,37 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
           // else {
           //   // this.handleFeedbackPopup();
           // }
-          const describers = { ...audioDescriptionsIdsUsers }
+          // The API returns the recomputed aggregate, so the stars show exactly
+          // what the next page load will. Adding to the local copy instead used
+          // to double-count: it always incremented the vote counter, even when
+          // the user was changing a rating they had already given, which the
+          // server correctly treats as a replacement rather than a new vote.
+          const { overallRating } = res as unknown as {
+            overallRating?: {
+              overall_rating_votes_sum: number
+              overall_rating_votes_counter: number
+              overall_rating_votes_average: number
+            }
+          }
           const selectedId = selectedADId
 
-          if (!describers[selectedId].overall_rating_votes_sum) {
-            describers[selectedId].overall_rating_votes_sum = 0
-          }
-          if (!describers[selectedId].overall_rating_votes_counter) {
-            describers[selectedId].overall_rating_votes_counter = 0
-          }
-          if (!describers[selectedId].overall_rating_average) {
-            describers[selectedId].overall_rating_average = 0
-          }
+          if (overallRating && audioDescriptionsIdsUsers?.[selectedId]) {
+            const describers = { ...audioDescriptionsIdsUsers }
+            describers[selectedId].overall_rating_votes_sum =
+              overallRating.overall_rating_votes_sum
+            describers[selectedId].overall_rating_votes_counter =
+              overallRating.overall_rating_votes_counter
+            describers[selectedId].overall_rating_average =
+              overallRating.overall_rating_votes_average
 
-          describers[selectedId].overall_rating_votes_sum += comprehensionRating
-          describers[selectedId].overall_rating_votes_counter += 1
-          describers[selectedId].overall_rating_average =
-            describers[selectedId].overall_rating_votes_sum /
-            describers[selectedId].overall_rating_votes_counter
-
-          setAudioDescriptionsIdsUsers(describers)
+            setAudioDescriptionsIdsUsers(describers)
+          }
         })
         .catch((err) => {
           // console.log(err)
-          toast.error(
+          // Keep the popup open so the answers are not lost, and report the
+          // failure inside it where the alert region is reachable.
+          setRatingSubmitError(
             translate(
               'It was impossible to vote. Maybe your session has expired. Try to logout and login again.',
             ),
@@ -1145,11 +1156,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
     if (!userDataStore.getState().isSignedIn) {
       toast.error(translate('You have to be logged in in order to vote'))
     } else {
-      const ratingPopup = document.getElementById('rating-popup')
-      if (ratingPopup) {
-        ratingPopup.style.display = 'block'
-        ratingPopup.focus()
-      }
+      openRatingPopup()
     }
   }
   // const handleFeedbackPopup = () => {
@@ -1167,10 +1174,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
   // }
 
   const handleRatingPopupClose = () => {
-    const ratingPopup = document.getElementById('rating-popup')
-    if (ratingPopup) {
-      ratingPopup.style.display = 'none'
-    }
+    closeRatingPopup()
   }
 
   // const handleFeedbackPopupClose = () => {
@@ -1552,7 +1556,13 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
 
   return (
     <div id="video-page" className="video-page">
-      <main role="main" className="video-page-main" title="Video page">
+      {/* The page had no banner landmark and no h1 at all. The title is already
+          shown visually by YTInfoCard, so this is the screen-reader-only
+          equivalent rather than a second visible header bar. */}
+      <header role="banner" className="visually-hidden">
+        <h1>{videoTitle || translate('Video')}</h1>
+      </header>
+      <main role="main" className="video-page-main" aria-label="Video page">
         <section id="video-area" className="video-area">
           {/* <ToastContainer /> */}
           <ShareBar videoTitle={videoTitle} />
@@ -1610,6 +1620,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
           className="classic-container w3-row video-info"
         >
           <RatingPopup
+            isOpen={isRatingPopupOpen}
             audioDescriptionId={selectedADId}
             comprehensionRating={rating}
             setComprehensionRating={setRating}
@@ -1617,12 +1628,25 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
             setEnjoymentRating={setEnjoymentRating}
             comment={ratingComment}
             setComment={setRatingComment}
+            submitError={ratingSubmitError}
             handleRatingSubmit={handleRatingSubmit}
             handleRatingPopupClose={handleRatingPopupClose}
           />
-          <div id="rating-success" className="rating-success" tabIndex={-1}>
-            {translate('Thanks for rating this description!')}
+          {/* Announcement channel: always mounted so the live region is
+              registered before it gains text. The visual confirmation below is
+              a separate node, hidden from assistive tech to avoid saying it twice. */}
+          <div className="visually-hidden" role="status">
+            {ratingSuccessMessage}
           </div>
+          {ratingSuccessMessage && (
+            <div
+              id="rating-success"
+              className="rating-success"
+              aria-hidden="true"
+            >
+              {ratingSuccessMessage}
+            </div>
+          )}
           {/* Optional feedback UI disabled — data field (`feedback`) kept on the rating payload.
           <FeedbackPopup
             handleFeedbackSubmit={handleFeedbackSubmit}

--- a/src/pages/Video/Video.tsx
+++ b/src/pages/Video/Video.tsx
@@ -33,7 +33,8 @@ import { convertLikesToCardFormat } from '@/shared/utils/convertLikesToCardForma
 import { convertISO8601ToDate } from '@/shared/utils/convertISO8601ToDate'
 import DescriberCard from '@/features/Video/DescriberCard/DescriberCard'
 import RatingPopup from '@/features/Video/RatingPopup/RatingPopup'
-import FeedbackPopup from '@/features/Video/FeedbackPopup/FeedbackPopup'
+// Optional feedback UI disabled — see commented-out usages below. Data field (`feedback`) is still sent/stored.
+// import FeedbackPopup from '@/features/Video/FeedbackPopup/FeedbackPopup'
 import RatingsInfoCard from '@/features/Video/RatingsInfoCard/RatingsInfoCard'
 import { ProgressBar } from 'react-bootstrap'
 import axios from 'axios'
@@ -851,7 +852,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
             key={i}
             handleDescriberChange={handleDescriberChange}
             handleRatingPopup={handleRatingPopup}
-            handleFeedbackPopup={handleFeedbackPopup}
+            // handleFeedbackPopup={handleFeedbackPopup}
             handleNewCollabEdit={() => handleNewCollabEdit(selectedADId)}
             describerId={describerId}
             selectedDescriberId={selectedADId}
@@ -1066,46 +1067,47 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
     }
   }
 
-  const handleFeedbackSubmit = (feedback: any) => {
-    const url = `${apiUrl}/audio-descriptions/ratings/addOne/${selectedADId}`
-    ourFetch(url, true, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        userId: userDataStore.getState().userId,
-        userToken: userDataStore.getState().userToken,
-        rating: rating,
-        feedback,
-      }),
-    })
-      .then((res) => {
-        const feedbackPopup = document.getElementById('feedback-popup')
-        const feedbackSuccess = document.getElementById('feedback-success')
-        if (feedbackPopup) {
-          feedbackPopup.style.display = 'none'
-        }
-        if (feedbackSuccess) {
-          feedbackSuccess.style.display = 'block'
-          feedbackSuccess.focus()
-          setTimeout(() => (feedbackSuccess.style.display = 'none'), 1000)
-        }
-        // toast.error('Thanks for your feedback!');
-
-        /* start of email */
-        sendOptInEmail(2, rating, feedback)
-        /* end of email */
-      })
-      .catch((err) => {
-        // console.log(err)
-        toast.error(
-          translate(
-            'It was impossible to vote. Maybe your session has expired. Try to logout and login again.',
-          ),
-        )
-      })
-  }
+  // Optional feedback UI disabled — data field (`feedback`) kept on the rating payload, just never populated from the UI anymore.
+  // const handleFeedbackSubmit = (feedback: any) => {
+  //   const url = `${apiUrl}/audio-descriptions/ratings/addOne/${selectedADId}`
+  //   ourFetch(url, true, {
+  //     method: 'POST',
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //     },
+  //     body: JSON.stringify({
+  //       userId: userDataStore.getState().userId,
+  //       userToken: userDataStore.getState().userToken,
+  //       rating: rating,
+  //       feedback,
+  //     }),
+  //   })
+  //     .then((res) => {
+  //       const feedbackPopup = document.getElementById('feedback-popup')
+  //       const feedbackSuccess = document.getElementById('feedback-success')
+  //       if (feedbackPopup) {
+  //         feedbackPopup.style.display = 'none'
+  //       }
+  //       if (feedbackSuccess) {
+  //         feedbackSuccess.style.display = 'block'
+  //         feedbackSuccess.focus()
+  //         setTimeout(() => (feedbackSuccess.style.display = 'none'), 1000)
+  //       }
+  //       // toast.error('Thanks for your feedback!');
+  //
+  //       /* start of email */
+  //       sendOptInEmail(2, rating, feedback)
+  //       /* end of email */
+  //     })
+  //     .catch((err) => {
+  //       // console.log(err)
+  //       toast.error(
+  //         translate(
+  //           'It was impossible to vote. Maybe your session has expired. Try to logout and login again.',
+  //         ),
+  //       )
+  //     })
+  // }
 
   const sendOptInEmail = (optIn: number, rating = 0, feedback = []) => {
     let emailBody = ''
@@ -1150,19 +1152,19 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
       }
     }
   }
-  const handleFeedbackPopup = () => {
-    if (!userDataStore.getState().isSignedIn) {
-      toast.error(
-        translate('You have to be logged in in order to give feedback'),
-      )
-    } else {
-      const feedbackPopup = document.getElementById('feedback-popup')
-      if (feedbackPopup) {
-        feedbackPopup.style.display = 'block'
-        feedbackPopup.focus()
-      }
-    }
-  }
+  // const handleFeedbackPopup = () => {
+  //   if (!userDataStore.getState().isSignedIn) {
+  //     toast.error(
+  //       translate('You have to be logged in in order to give feedback'),
+  //     )
+  //   } else {
+  //     const feedbackPopup = document.getElementById('feedback-popup')
+  //     if (feedbackPopup) {
+  //       feedbackPopup.style.display = 'block'
+  //       feedbackPopup.focus()
+  //     }
+  //   }
+  // }
 
   const handleRatingPopupClose = () => {
     const ratingPopup = document.getElementById('rating-popup')
@@ -1171,12 +1173,12 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
     }
   }
 
-  const handleFeedbackPopupClose = () => {
-    const feedbackPopup = document.getElementById('feedback-popup')
-    if (feedbackPopup) {
-      feedbackPopup.style.display = 'none'
-    }
-  }
+  // const handleFeedbackPopupClose = () => {
+  //   const feedbackPopup = document.getElementById('feedback-popup')
+  //   if (feedbackPopup) {
+  //     feedbackPopup.style.display = 'none'
+  //   }
+  // }
 
   // console.log(videoDurationInSeconds)
 
@@ -1621,6 +1623,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
           <div id="rating-success" className="rating-success" tabIndex={-1}>
             {translate('Thanks for rating this description!')}
           </div>
+          {/* Optional feedback UI disabled — data field (`feedback`) kept on the rating payload.
           <FeedbackPopup
             handleFeedbackSubmit={handleFeedbackSubmit}
             handleFeedbackPopupClose={handleFeedbackPopupClose}
@@ -1628,6 +1631,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
           <div id="feedback-success" className="feedback-success" tabIndex={-1}>
             {translate('Thank you for your feedback!')}
           </div>
+          */}
           <div className="w3-col l8 m8">
             <YTInfoCard
               videoTitle={videoTitle}

--- a/src/pages/Video/Video.tsx
+++ b/src/pages/Video/Video.tsx
@@ -89,6 +89,8 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
   const [describerCards, setDescriberCards] = useState<ReactNode[]>([])
   const [descriptionsActive, setDescriptionsActive] = useState(true)
   const [rating, setRating] = useState<number>(0)
+  const [enjoymentRating, setEnjoymentRating] = useState<number>(0)
+  const [ratingComment, setRatingComment] = useState<string>('')
   // const codes = iso6391.getAllCodes()
 
   const languages = [
@@ -986,13 +988,17 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
     currentEventRef.current?.playVideo() // Optional: auto-resume video when turned back on
   }
 
-  const handleRatingSubmit = (rating: number) => {
-    if (rating === 0) toast.error('You must select a rating')
+  const handleRatingSubmit = (
+    comprehensionRating: number,
+    enjoymentScore: number,
+    ratingCommentText: string,
+  ) => {
+    if (comprehensionRating === 0 || enjoymentScore === 0)
+      toast.error(translate('Please answer both questions'))
     else if (!userDataStore.getState().isSignedIn) {
       toast.error(translate('You have to be logged in in order to vote'))
     } else {
       const url = `${apiUrl}/audio-descriptions/ratings/addOne/${selectedADId}`
-      setRating(rating)
       ourFetch(url, true, {
         method: 'POST',
         headers: {
@@ -1001,7 +1007,9 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
         body: JSON.stringify({
           userId: userDataStore.getState().userId,
           userToken: userDataStore.getState().userToken,
-          rating,
+          rating: comprehensionRating,
+          enjoymentRating: enjoymentScore,
+          comment: ratingCommentText.trim(),
         }),
       })
         .then((res) => {
@@ -1019,7 +1027,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
           }
 
           /* start of email */
-          sendOptInEmail(2, rating, [])
+          sendOptInEmail(2, comprehensionRating, [])
           /* end of email */
 
           // }
@@ -1039,7 +1047,7 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
             describers[selectedId].overall_rating_average = 0
           }
 
-          describers[selectedId].overall_rating_votes_sum += rating
+          describers[selectedId].overall_rating_votes_sum += comprehensionRating
           describers[selectedId].overall_rating_votes_counter += 1
           describers[selectedId].overall_rating_average =
             describers[selectedId].overall_rating_votes_sum /
@@ -1601,8 +1609,12 @@ const Video = ({ isTutorialMode = false }: VideoProps) => {
         >
           <RatingPopup
             audioDescriptionId={selectedADId}
-            rating={rating}
-            setRating={setRating}
+            comprehensionRating={rating}
+            setComprehensionRating={setRating}
+            enjoymentRating={enjoymentRating}
+            setEnjoymentRating={setEnjoymentRating}
+            comment={ratingComment}
+            setComment={setRatingComment}
             handleRatingSubmit={handleRatingSubmit}
             handleRatingPopupClose={handleRatingPopupClose}
           />

--- a/src/pages/Video/Video_v2.tsx
+++ b/src/pages/Video/Video_v2.tsx
@@ -48,6 +48,8 @@ const Video = () => {
   const [describerCards, setDescriberCards] = useState<ReactNode[]>([])
   const [descriptionsActive, setDescriptionsActive] = useState(true)
   const [rating, setRating] = useState<number>(0)
+  const [enjoymentRating, setEnjoymentRating] = useState<number>(0)
+  const [ratingComment, setRatingComment] = useState<string>('')
 
   // Loading Spinner
   const [showSpinner, setShowSpinner] = useState(true)
@@ -1151,13 +1153,17 @@ const Video = () => {
     setDescriptionsActive(true)
   }
 
-  const handleRatingSubmit = (rating: number) => {
-    if (rating === 0) toast.error('You must select a rating')
+  const handleRatingSubmit = (
+    comprehensionRating: number,
+    enjoymentScore: number,
+    ratingCommentText: string,
+  ) => {
+    if (comprehensionRating === 0 || enjoymentScore === 0)
+      toast.error(translate('Please answer both questions'))
     else if (!userDataStore.getState().isSignedIn) {
       toast.error(translate('You have to be logged in in order to vote'))
     } else {
       const url = `${apiUrl}/audio-descriptions/ratings/addOne/${selectedADId}`
-      setRating(rating)
       ourFetch(url, true, {
         method: 'POST',
         headers: {
@@ -1166,7 +1172,9 @@ const Video = () => {
         body: JSON.stringify({
           userId: userDataStore.getState().userId,
           userToken: userDataStore.getState().userToken,
-          rating,
+          rating: comprehensionRating,
+          enjoymentRating: enjoymentScore,
+          comment: ratingCommentText.trim(),
         }),
       })
         .then((res) => {
@@ -1184,7 +1192,7 @@ const Video = () => {
           }
 
           /* start of email */
-          sendOptInEmail(2, rating, [])
+          sendOptInEmail(2, comprehensionRating, [])
           /* end of email */
 
           // }
@@ -1204,7 +1212,7 @@ const Video = () => {
             describers[selectedId].overall_rating_average = 0
           }
 
-          describers[selectedId].overall_rating_votes_sum += rating
+          describers[selectedId].overall_rating_votes_sum += comprehensionRating
           describers[selectedId].overall_rating_votes_counter += 1
           describers[selectedId].overall_rating_average =
             describers[selectedId].overall_rating_votes_sum /
@@ -1559,8 +1567,12 @@ const Video = () => {
         >
           <RatingPopup
             audioDescriptionId={selectedADId}
-            rating={rating}
-            setRating={setRating}
+            comprehensionRating={rating}
+            setComprehensionRating={setRating}
+            enjoymentRating={enjoymentRating}
+            setEnjoymentRating={setEnjoymentRating}
+            comment={ratingComment}
+            setComment={setRatingComment}
             handleRatingSubmit={handleRatingSubmit}
             handleRatingPopupClose={handleRatingPopupClose}
           />

--- a/src/pages/Video/Video_v2.tsx
+++ b/src/pages/Video/Video_v2.tsx
@@ -33,6 +33,7 @@ import { convertLikesToCardFormat } from '@/shared/utils/convertLikesToCardForma
 import { convertISO8601ToDate } from '@/shared/utils/convertISO8601ToDate'
 import DescriberCard from '@/features/Video/DescriberCard/DescriberCard'
 import RatingPopup from '@/features/Video/RatingPopup/RatingPopup'
+import { useRatingPopup } from '@/features/Video/RatingPopup/useRatingPopup'
 // Optional feedback UI disabled — see commented-out usages below. Data field (`feedback`) is still sent/stored.
 // import FeedbackPopup from '@/features/Video/FeedbackPopup/FeedbackPopup'
 import RatingsInfoCard from '@/features/Video/RatingsInfoCard/RatingsInfoCard'
@@ -51,6 +52,15 @@ const Video = () => {
   const [rating, setRating] = useState<number>(0)
   const [enjoymentRating, setEnjoymentRating] = useState<number>(0)
   const [ratingComment, setRatingComment] = useState<string>('')
+  const {
+    isRatingPopupOpen,
+    openRatingPopup,
+    closeRatingPopup,
+    completeRatingPopup,
+    ratingSubmitError,
+    setRatingSubmitError,
+    ratingSuccessMessage,
+  } = useRatingPopup()
 
   // Loading Spinner
   const [showSpinner, setShowSpinner] = useState(true)
@@ -316,7 +326,11 @@ const Video = () => {
           adIdsUsers[ad._id] = ad.user
           adIdsUsers[ad._id].overall_rating_votes_counter =
             ad.overall_rating_votes_counter
-          adIdsUsers[ad._id].overall_rating_average = ad.overall_rating_average
+          // The API field is overall_rating_votes_average; reading
+          // ad.overall_rating_average here yielded undefined, so the stars
+          // rendered as NaN and the label always said "no ratings".
+          adIdsUsers[ad._id].overall_rating_average =
+            ad.overall_rating_votes_average
           adIdsUsers[ad._id].overall_rating_votes_sum =
             ad.overall_rating_votes_sum
           adIdsUsers[ad._id].feedbacks = ad.feedbacks
@@ -1159,10 +1173,12 @@ const Video = () => {
     enjoymentScore: number,
     ratingCommentText: string,
   ) => {
-    if (comprehensionRating === 0 || enjoymentScore === 0)
-      toast.error(translate('Please answer both questions'))
-    else if (!userDataStore.getState().isSignedIn) {
-      toast.error(translate('You have to be logged in in order to vote'))
+    // The popup validates that both questions are answered and reports it in its
+    // own alert region, so this only has to handle session/server failures.
+    if (!userDataStore.getState().isSignedIn) {
+      setRatingSubmitError(
+        translate('You have to be logged in in order to vote'),
+      )
     } else {
       const url = `${apiUrl}/audio-descriptions/ratings/addOne/${selectedADId}`
       ourFetch(url, true, {
@@ -1179,18 +1195,10 @@ const Video = () => {
         }),
       })
         .then((res) => {
-          // if (rating === 5) {
-          // toast.error(`You have successfully given this description a rating of ${rating}`);
-          const ratingPopup = document.getElementById('rating-popup')
-          const ratingSuccess = document.getElementById('rating-success')
-          if (ratingPopup) {
-            ratingPopup.style.display = 'none'
-          }
-          if (ratingSuccess) {
-            ratingSuccess.style.display = 'block'
-            ratingSuccess.focus()
-            setTimeout(() => (ratingSuccess.style.display = 'none'), 1000)
-          }
+          // Closes the popup (which hands focus back to the trigger) and puts the
+          // confirmation in a live region instead of focusing a div that is then
+          // torn down a second later.
+          completeRatingPopup(translate('Thanks for rating this description!'))
 
           /* start of email */
           sendOptInEmail(2, comprehensionRating, [])
@@ -1200,30 +1208,37 @@ const Video = () => {
           // else {
           //   // this.handleFeedbackPopup();
           // }
-          const describers = { ...audioDescriptionsIdsUsers }
+          // The API returns the recomputed aggregate, so the stars show exactly
+          // what the next page load will. Adding to the local copy instead used
+          // to double-count: it always incremented the vote counter, even when
+          // the user was changing a rating they had already given, which the
+          // server correctly treats as a replacement rather than a new vote.
+          const { overallRating } = res as unknown as {
+            overallRating?: {
+              overall_rating_votes_sum: number
+              overall_rating_votes_counter: number
+              overall_rating_votes_average: number
+            }
+          }
           const selectedId = selectedADId
 
-          if (!describers[selectedId].overall_rating_votes_sum) {
-            describers[selectedId].overall_rating_votes_sum = 0
-          }
-          if (!describers[selectedId].overall_rating_votes_counter) {
-            describers[selectedId].overall_rating_votes_counter = 0
-          }
-          if (!describers[selectedId].overall_rating_average) {
-            describers[selectedId].overall_rating_average = 0
-          }
+          if (overallRating && audioDescriptionsIdsUsers?.[selectedId]) {
+            const describers = { ...audioDescriptionsIdsUsers }
+            describers[selectedId].overall_rating_votes_sum =
+              overallRating.overall_rating_votes_sum
+            describers[selectedId].overall_rating_votes_counter =
+              overallRating.overall_rating_votes_counter
+            describers[selectedId].overall_rating_average =
+              overallRating.overall_rating_votes_average
 
-          describers[selectedId].overall_rating_votes_sum += comprehensionRating
-          describers[selectedId].overall_rating_votes_counter += 1
-          describers[selectedId].overall_rating_average =
-            describers[selectedId].overall_rating_votes_sum /
-            describers[selectedId].overall_rating_votes_counter
-
-          setAudioDescriptionsIdsUsers(describers)
+            setAudioDescriptionsIdsUsers(describers)
+          }
         })
         .catch((err) => {
           // console.log(err)
-          toast.error(
+          // Keep the popup open so the answers are not lost, and report the
+          // failure inside it where the alert region is reachable.
+          setRatingSubmitError(
             translate(
               'It was impossible to vote. Maybe your session has expired. Try to logout and login again.',
             ),
@@ -1310,11 +1325,7 @@ const Video = () => {
     if (!userDataStore.getState().isSignedIn) {
       toast.error(translate('You have to be logged in in order to vote'))
     } else {
-      const ratingPopup = document.getElementById('rating-popup')
-      if (ratingPopup) {
-        ratingPopup.style.display = 'block'
-        ratingPopup.focus()
-      }
+      openRatingPopup()
     }
   }
   // const handleFeedbackPopup = () => {
@@ -1332,10 +1343,7 @@ const Video = () => {
   // }
 
   const handleRatingPopupClose = () => {
-    const ratingPopup = document.getElementById('rating-popup')
-    if (ratingPopup) {
-      ratingPopup.style.display = 'none'
-    }
+    closeRatingPopup()
   }
 
   // const handleFeedbackPopupClose = () => {
@@ -1512,7 +1520,13 @@ const Video = () => {
 
   return (
     <div id="video-page" className="video-page">
-      <main role="main" className="video-page-main" title="Video page">
+      {/* The page had no banner landmark and no h1 at all. The title is already
+          shown visually by YTInfoCard, so this is the screen-reader-only
+          equivalent rather than a second visible header bar. */}
+      <header role="banner" className="visually-hidden">
+        <h1>{videoTitle || translate('Video')}</h1>
+      </header>
+      <main role="main" className="video-page-main" aria-label="Video page">
         <section id="video-area" className="video-area">
           {/* <ToastContainer /> */}
           <ShareBar videoTitle={videoTitle} />
@@ -1568,6 +1582,7 @@ const Video = () => {
           className="classic-container w3-row video-info"
         >
           <RatingPopup
+            isOpen={isRatingPopupOpen}
             audioDescriptionId={selectedADId}
             comprehensionRating={rating}
             setComprehensionRating={setRating}
@@ -1575,12 +1590,25 @@ const Video = () => {
             setEnjoymentRating={setEnjoymentRating}
             comment={ratingComment}
             setComment={setRatingComment}
+            submitError={ratingSubmitError}
             handleRatingSubmit={handleRatingSubmit}
             handleRatingPopupClose={handleRatingPopupClose}
           />
-          <div id="rating-success" className="rating-success" tabIndex={-1}>
-            {translate('Thanks for rating this description!')}
+          {/* Announcement channel: always mounted so the live region is
+              registered before it gains text. The visual confirmation below is
+              a separate node, hidden from assistive tech to avoid saying it twice. */}
+          <div className="visually-hidden" role="status">
+            {ratingSuccessMessage}
           </div>
+          {ratingSuccessMessage && (
+            <div
+              id="rating-success"
+              className="rating-success"
+              aria-hidden="true"
+            >
+              {ratingSuccessMessage}
+            </div>
+          )}
           {/* Optional feedback UI disabled — data field (`feedback`) kept on the rating payload.
           <FeedbackPopup
             handleFeedbackSubmit={handleFeedbackSubmit}

--- a/src/pages/Video/Video_v2.tsx
+++ b/src/pages/Video/Video_v2.tsx
@@ -33,7 +33,8 @@ import { convertLikesToCardFormat } from '@/shared/utils/convertLikesToCardForma
 import { convertISO8601ToDate } from '@/shared/utils/convertISO8601ToDate'
 import DescriberCard from '@/features/Video/DescriberCard/DescriberCard'
 import RatingPopup from '@/features/Video/RatingPopup/RatingPopup'
-import FeedbackPopup from '@/features/Video/FeedbackPopup/FeedbackPopup'
+// Optional feedback UI disabled — see commented-out usages below. Data field (`feedback`) is still sent/stored.
+// import FeedbackPopup from '@/features/Video/FeedbackPopup/FeedbackPopup'
 import RatingsInfoCard from '@/features/Video/RatingsInfoCard/RatingsInfoCard'
 import { ProgressBar } from 'react-bootstrap'
 import axios from 'axios'
@@ -986,7 +987,7 @@ const Video = () => {
           key={i}
           handleDescriberChange={handleDescriberChange}
           handleRatingPopup={handleRatingPopup}
-          handleFeedbackPopup={handleFeedbackPopup}
+          // handleFeedbackPopup={handleFeedbackPopup}
           handleNewCollabEdit={handleNewCollabEdit}
           describerId={describerId}
           selectedDescriberId={selectedADId}
@@ -1231,46 +1232,47 @@ const Video = () => {
     }
   }
 
-  const handleFeedbackSubmit = (feedback: any) => {
-    const url = `${apiUrl}/audio-descriptions/ratings/addOne/${selectedADId}`
-    ourFetch(url, true, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        userId: userDataStore.getState().userId,
-        userToken: userDataStore.getState().userToken,
-        rating: rating,
-        feedback,
-      }),
-    })
-      .then((res) => {
-        const feedbackPopup = document.getElementById('feedback-popup')
-        const feedbackSuccess = document.getElementById('feedback-success')
-        if (feedbackPopup) {
-          feedbackPopup.style.display = 'none'
-        }
-        if (feedbackSuccess) {
-          feedbackSuccess.style.display = 'block'
-          feedbackSuccess.focus()
-          setTimeout(() => (feedbackSuccess.style.display = 'none'), 1000)
-        }
-        // toast.error('Thanks for your feedback!');
-
-        /* start of email */
-        sendOptInEmail(2, rating, feedback)
-        /* end of email */
-      })
-      .catch((err) => {
-        // console.log(err)
-        toast.error(
-          translate(
-            'It was impossible to vote. Maybe your session has expired. Try to logout and login again.',
-          ),
-        )
-      })
-  }
+  // Optional feedback UI disabled — data field (`feedback`) kept on the rating payload, just never populated from the UI anymore.
+  // const handleFeedbackSubmit = (feedback: any) => {
+  //   const url = `${apiUrl}/audio-descriptions/ratings/addOne/${selectedADId}`
+  //   ourFetch(url, true, {
+  //     method: 'POST',
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //     },
+  //     body: JSON.stringify({
+  //       userId: userDataStore.getState().userId,
+  //       userToken: userDataStore.getState().userToken,
+  //       rating: rating,
+  //       feedback,
+  //     }),
+  //   })
+  //     .then((res) => {
+  //       const feedbackPopup = document.getElementById('feedback-popup')
+  //       const feedbackSuccess = document.getElementById('feedback-success')
+  //       if (feedbackPopup) {
+  //         feedbackPopup.style.display = 'none'
+  //       }
+  //       if (feedbackSuccess) {
+  //         feedbackSuccess.style.display = 'block'
+  //         feedbackSuccess.focus()
+  //         setTimeout(() => (feedbackSuccess.style.display = 'none'), 1000)
+  //       }
+  //       // toast.error('Thanks for your feedback!');
+  //
+  //       /* start of email */
+  //       sendOptInEmail(2, rating, feedback)
+  //       /* end of email */
+  //     })
+  //     .catch((err) => {
+  //       // console.log(err)
+  //       toast.error(
+  //         translate(
+  //           'It was impossible to vote. Maybe your session has expired. Try to logout and login again.',
+  //         ),
+  //       )
+  //     })
+  // }
 
   const sendOptInEmail = (optIn: number, rating = 0, feedback = []) => {
     let emailBody = ''
@@ -1315,19 +1317,19 @@ const Video = () => {
       }
     }
   }
-  const handleFeedbackPopup = () => {
-    if (!userDataStore.getState().isSignedIn) {
-      toast.error(
-        translate('You have to be logged in in order to give feedback'),
-      )
-    } else {
-      const feedbackPopup = document.getElementById('feedback-popup')
-      if (feedbackPopup) {
-        feedbackPopup.style.display = 'block'
-        feedbackPopup.focus()
-      }
-    }
-  }
+  // const handleFeedbackPopup = () => {
+  //   if (!userDataStore.getState().isSignedIn) {
+  //     toast.error(
+  //       translate('You have to be logged in in order to give feedback'),
+  //     )
+  //   } else {
+  //     const feedbackPopup = document.getElementById('feedback-popup')
+  //     if (feedbackPopup) {
+  //       feedbackPopup.style.display = 'block'
+  //       feedbackPopup.focus()
+  //     }
+  //   }
+  // }
 
   const handleRatingPopupClose = () => {
     const ratingPopup = document.getElementById('rating-popup')
@@ -1336,12 +1338,12 @@ const Video = () => {
     }
   }
 
-  const handleFeedbackPopupClose = () => {
-    const feedbackPopup = document.getElementById('feedback-popup')
-    if (feedbackPopup) {
-      feedbackPopup.style.display = 'none'
-    }
-  }
+  // const handleFeedbackPopupClose = () => {
+  //   const feedbackPopup = document.getElementById('feedback-popup')
+  //   if (feedbackPopup) {
+  //     feedbackPopup.style.display = 'none'
+  //   }
+  // }
 
   // console.log(videoDurationInSeconds)
 
@@ -1579,6 +1581,7 @@ const Video = () => {
           <div id="rating-success" className="rating-success" tabIndex={-1}>
             {translate('Thanks for rating this description!')}
           </div>
+          {/* Optional feedback UI disabled — data field (`feedback`) kept on the rating payload.
           <FeedbackPopup
             handleFeedbackSubmit={handleFeedbackSubmit}
             handleFeedbackPopupClose={handleFeedbackPopupClose}
@@ -1586,6 +1589,7 @@ const Video = () => {
           <div id="feedback-success" className="feedback-success" tabIndex={-1}>
             {translate('Thank you for your feedback!')}
           </div>
+          */}
           <div className="w3-col l8 m8">
             <YTInfoCard
               videoTitle={videoTitle}

--- a/src/pages/Video/video.scss
+++ b/src/pages/Video/video.scss
@@ -143,9 +143,14 @@
     }
   }
 
-  .feedback-success,
-  .rating-success {
+  .feedback-success {
     display: none;
+  }
+
+  // Rendered only while there is a message to show (see Video.tsx), so it no
+  // longer needs to be toggled from JS.
+  .rating-success {
+    display: block;
     position: fixed;
     background-color: #fff;
     color: #3f51b5;

--- a/src/shared/components/Button/Button.tsx
+++ b/src/shared/components/Button/Button.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from 'react'
 
 interface Props {
   ariaLabel: string
+  /** Id of an element whose text is read after the label, e.g. a rating summary. */
+  ariaDescribedBy?: string
   id?: string
   title?: string
   color: string
@@ -13,6 +15,7 @@ interface Props {
 
 const Button = ({
   ariaLabel,
+  ariaDescribedBy,
   id,
   title,
   color,
@@ -25,6 +28,7 @@ const Button = ({
     <div id="button">
       <button
         aria-label={ariaLabel}
+        aria-describedby={ariaDescribedBy}
         id={id}
         title={title}
         className={`w3-btn ${color} ${classNames}`}

--- a/src/shared/strings.ts
+++ b/src/shared/strings.ts
@@ -156,6 +156,29 @@ const strings = {
     'Description Detail': 'Descrição Detalhe',
     'My profile': 'Meus perfil',
     Admin: 'Admin',
+    'Two quick questions': 'Duas perguntas rápidas',
+    'About the video you just watched.':
+      'Sobre o vídeo que você acabou de assistir.',
+    'How well were you able to follow what was happening in the video?':
+      'Quão bem você conseguiu acompanhar o que acontecia no vídeo?',
+    'How much did you enjoy the video?': 'Quanto você gostou do vídeo?',
+    "Anything else you'd like us to know?":
+      'Mais alguma coisa que você gostaria de nos contar?',
+    optional: 'opcional',
+    'Optional — any other thoughts about the video or its description.':
+      'Opcional — outros comentários sobre o vídeo ou sua audiodescrição.',
+    'Stop dictation': 'Parar ditado',
+    'Dictate your answer': 'Dite sua resposta',
+    'Listening…': 'Ouvindo…',
+    Back: 'Voltar',
+    'Submit & finish': 'Enviar e finalizar',
+    'Not at all': 'Nem um pouco',
+    'A little': 'Um pouco',
+    Somewhat: 'Razoavelmente',
+    Mostly: 'Na maior parte',
+    Completely: 'Completamente',
+    'Quite a bit': 'Bastante',
+    'A great deal': 'Muitíssimo',
   },
   'en-us': {
     'RECENT DESCRIPTIONS': 'RECENT DESCRIPTIONS',
@@ -328,6 +351,28 @@ const strings = {
     'Provide feedback for this describer':
       'Provide feedback for this describer',
     'MY DESCRIPTIONS': 'MY DESCRIPTIONS',
+    'Two quick questions': 'Two quick questions',
+    'About the video you just watched.': 'About the video you just watched.',
+    'How well were you able to follow what was happening in the video?':
+      'How well were you able to follow what was happening in the video?',
+    'How much did you enjoy the video?': 'How much did you enjoy the video?',
+    "Anything else you'd like us to know?":
+      "Anything else you'd like us to know?",
+    optional: 'optional',
+    'Optional — any other thoughts about the video or its description.':
+      'Optional — any other thoughts about the video or its description.',
+    'Stop dictation': 'Stop dictation',
+    'Dictate your answer': 'Dictate your answer',
+    'Listening…': 'Listening…',
+    Back: 'Back',
+    'Submit & finish': 'Submit & finish',
+    'Not at all': 'Not at all',
+    'A little': 'A little',
+    Somewhat: 'Somewhat',
+    Mostly: 'Mostly',
+    Completely: 'Completely',
+    'Quite a bit': 'Quite a bit',
+    'A great deal': 'A great deal',
   },
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Replaces the single-star rating widget with a two-question rating form and an
optional free-text comment.
- The rating POST now sends `enjoymentRating` and `comment` alongside `rating`.
- Reopening the dialog prefills all three fields from the user's existing rating
  via `GET /audio-descriptions/ratings/user/:id`.
- Accessibility: Follows the guide to Accessibility Testing with Screen Readers.
- The optional-feedback UI (`FeedbackPopup`, `handleFeedbackSubmit`,
  `handleFeedbackPopup`, the DescriberCard button) is **commented out rather
  than deleted**, and the `feedback` field stays on the request payload — it's
  simply no longer populated from the UI.
- Added 19 missing i18n keys to `src/shared/strings.ts` (`en-us` + `pt-br`) for
  every string the new dialog renders, including both scales' captions.
- Added average rating score calculation for the 5-star thumbnail (avg: comprehension + enjoyment).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To match the rate-ad website (https://rate-ad-2026.web.app/).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
**Environment:** local — app on `:3000` (Craco dev server), API on `:4001`
(`NODE_ENV=development`), shared dev Atlas cluster.

**Manual testing:**

- Rate a published AD as a non-owner: both scales, comment, submit
- Submit with one scale unanswered → "Please answer both questions"
- Submit while signed out → "You have to be logged in in order to vote"
- Reopen the dialog → previous rating, enjoyment, and comment are prefilled
- Dictation: mic button records into the comment box (Chrome/Safari); button is absent in a browser without SpeechRecognition (Firefox)
- Keyboard-only: Tab through both scales, Esc closes, focus is trapped
- Screen reader: follows the guide (https://achecker.ca/blog/screen-reader-testing)
- Owner-side rating email arrives (requires the API branch + `opt_in_ai_feedback` on the owner; note the rater must not be the owner)
- Average rating score: the rating thumbnail shows a half star when the rating score is not an integer; the screen reader reads aloud the average score with a decimal

## Screenshots (if appropriate):
<img width="1354" height="1076" alt="image" src="https://github.com/user-attachments/assets/21b4f882-bf18-447e-a154-b6d402da3e41" />
<img width="1654" height="564" alt="image" src="https://github.com/user-attachments/assets/a7b72d44-36ee-4886-9912-338ffb7895aa" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
