### PR TITLE
ci: fix cleanup stage failing on in-use image (port of api #123)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,6 @@ cleanup:
   stage: cleanup
   script:
     - echo "Cleaning up old images..."
-    - docker images --format "{{.ID}} {{.Repository}}" | grep "${DOCKER_REGISTRY}/${CI_PROJECT_NAME}" | sort -k2 | awk 'NR>1 {print $1}' | xargs -r docker rmi
     - docker container prune -f
     - docker image prune -af
   tags:


### PR DESCRIPTION
## What

Removes the explicit `docker rmi` line from the cleanup stage, keeping `docker container prune -f` + `docker image prune -af` — identical to the fix already applied to YouDescribeX-api in #123.

## Why

The `docker rmi` tries to delete the image that the currently running container uses:

```
Error response from daemon: conflict: unable to delete 73e1919552f6 (cannot be forced) - image is being used by running container e5473120d203
ERROR: Job failed: exit status 1
```

The deploy itself succeeds, but the pipeline shows Failed — a false alarm on every dev/main deploy (seen again today on the #180 and #185 deploys). `docker image prune -af` already removes all unused images and by design never touches in-use ones, so the fragile line adds nothing.

## Note

CI-config only, no application code. Safe to merge anytime; if merged before #186, it rides along to main.